### PR TITLE
XDebug isn't enabled for all Travis CI PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - hhvm
   - nightly
 
+before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" = "php*" ]]; then phpenv config-add travisconfig.ini ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "hhv*" ]]; then cat travisconfig.ini >> /etc/hhvm/php.ini ; fi
+
 install:
   composer install --prefer-dist
 

--- a/travisconfig.ini
+++ b/travisconfig.ini
@@ -1,0 +1,1 @@
+extension="xdebug.so"


### PR DESCRIPTION
This should enable XDebug in PHP 7.1 and nightly to help with generating code coverage results
