### PR TITLE
Refactored the login process

### DIFF
--- a/app/Http/Authentication/AmazonLoginAuthenticator.php
+++ b/app/Http/Authentication/AmazonLoginAuthenticator.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Authentication;
+
+use App\Http\Wrappers\ICurlRequest;
+use App\User;
+use Illuminate\Http\Request;
+
+class AmazonLoginAuthenticator implements ILoginAuthenticator
+{
+    private $curlRequest;
+    private $userModel;
+
+    public function __construct(ICurlRequest $curlRequest, User $userModel)
+    {
+        $this->curlRequest = $curlRequest;
+        $this->userModel = $userModel;
+    }
+
+    public function processLoginRequest(Request $request)
+    {
+        $accessToken = $request->query('access_token');
+
+        if (empty($accessToken) || !$this->verifyUserTokenMatchesAmazonToken($accessToken)) {
+            return null;
+        }
+
+        $decodedUserProfile = $this->exchangeAccessTokenForDecodedUserProfile($accessToken);
+        $loggedInUser = $this->getLoggedInUserProfile($decodedUserProfile);
+
+        return $loggedInUser;
+    }
+
+    private function verifyUserTokenMatchesAmazonToken($accessToken)
+    {
+        $amazonOAuthUrl = 'https://api.amazon.com/auth/o2/tokeninfo?access_token=' . urlencode($accessToken);
+        $this->curlRequest->init($amazonOAuthUrl);
+        $this->curlRequest->setOption(CURLOPT_RETURNTRANSFER, true);
+        $amazonUserAccessTokenResultJson = $this->curlRequest->execute();
+        $this->curlRequest->close();
+        $decodedUserAccessTokenArray = json_decode($amazonUserAccessTokenResultJson);
+
+        if (!isset($decodedUserAccessTokenArray->aud)) {
+            return false;
+        }
+
+        $userToken = $decodedUserAccessTokenArray->aud;
+
+        if ($userToken != env('AMAZON_TOKEN')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function exchangeAccessTokenForDecodedUserProfile($accessToken)
+    {
+        $this->curlRequest->init('https://api.amazon.com/user/profile');
+        $httpHeaders = ['Authorization: bearer ' . $accessToken];
+        $this->curlRequest->setOption(CURLOPT_HTTPHEADER, $httpHeaders);
+        $this->curlRequest->setOption(CURLOPT_RETURNTRANSFER, true);
+        $amazonUserProfileCurlResultJson = $this->curlRequest->execute();
+        $this->curlRequest->close();
+        $decodedUserProfileArray = json_decode($amazonUserProfileCurlResultJson);
+
+        return $decodedUserProfileArray;
+    }
+
+    private function getLoggedInUserProfile($decodedUserProfile)
+    {
+        $userId = $decodedUserProfile->user_id;
+        $loggedInUser = $this->userModel->where('user_id', $userId)->first();
+
+        if ($loggedInUser === null) {
+            $loggedInUser = $this->userModel->add(
+                $decodedUserProfile->name,
+                $decodedUserProfile->email,
+                $decodedUserProfile->user_id
+            );
+        }
+
+        return $loggedInUser;
+    }
+}

--- a/app/Http/Authentication/ILoginAuthenticator.php
+++ b/app/Http/Authentication/ILoginAuthenticator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Authentication;
+
+use Illuminate\Http\Request;
+
+interface ILoginAuthenticator
+{
+    public function processLoginRequest(Request $request);
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,13 +6,9 @@ use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
     public function register()
     {
+        $this->app->bind('App\Http\Authentication\ILoginAuthenticator', 'App\Http\Authentication\AmazonLoginAuthenticator');
         $this->app->bind('App\Http\Wrappers\ICurlRequest', 'App\Http\Wrappers\CurlRequest');
     }
 }

--- a/tests/unit/authentication/AmazonLoginAuthenticatorTest.php
+++ b/tests/unit/authentication/AmazonLoginAuthenticatorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit\Authentication;
+
+use App\Http\Authentication\AmazonLoginAuthenticator;
+use App\Http\Wrappers\ICurlRequest;
+use App\User;
+use Illuminate\Http\Request;
+use Mockery;
+use Tests\TestCase;
+
+class AmazonLoginAuthenticatorTest extends TestCase
+{
+    private $amazonLoginAuthenticator;
+    private $mockCurlRequest;
+    private $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->mockCurlRequest = Mockery::mock(ICurlRequest::class);
+        $this->user = $this->createUser();
+
+        $mockUserTable = Mockery::mock(User::class);
+        $mockUserTable
+            ->shouldReceive('where')->withAnyArgs()->andReturn(Mockery::self())
+            ->shouldReceive('first')->withAnyArgs()->andReturn($this->user);
+        $this->app->instance(User::class, $mockUserTable);
+
+        $this->amazonLoginAuthenticator = new AmazonLoginAuthenticator($this->mockCurlRequest, $mockUserTable);
+    }
+
+    public function testProcessLogin_GivenValidCurlRequests_ReturnsExistingUser()
+    {
+        $this->givenValidCurlRequests(env('AMAZON_TOKEN'), 2, 3, 1, 2);
+
+        $result = $this->callProcessLoginRequest();
+
+        $this->assertEquals($this->user, $result);
+    }
+
+    public function testProcessLogin_GivenValidCurlRequests_ReturnsNewUser()
+    {
+        $user = $this->createUser();
+
+        $mockUserTable = Mockery::mock(User::class);
+        $mockUserTable
+            ->shouldReceive('where')->withAnyArgs()->once()->andReturn(Mockery::self())
+            ->shouldReceive('first')->once()
+            ->shouldReceive('add')->withAnyArgs()->once()->andReturn($user);
+        $this->app->instance(User::class, $mockUserTable);
+
+        $this->amazonLoginAuthenticator = new AmazonLoginAuthenticator($this->mockCurlRequest, $mockUserTable);
+
+        $this->givenValidCurlRequests(env('AMAZON_TOKEN'), 2, 3, 1, 2);
+
+        $result = $this->callProcessLoginRequest();
+
+        $this->assertEquals($user, $result);
+    }
+
+    public function testProcessLogin_GivenValidCurlRequestsWithNonmatchingAccessToken_ReturnsNull()
+    {
+        $this->givenValidCurlRequests(self::$faker->uuid(), 1, 1, 0, 1);
+
+        $result = $this->callProcessLoginRequest();
+
+        $this->assertNull($result);
+    }
+
+    public function testProcessLogin_GivenValidCurlRequestsNoTokenReturnedFromAmazon_ReturnsNull()
+    {
+        $this->givenBadAccessTokenCurlRequests(env('AMAZON_TOKEN'), 1, 1, 1);
+
+        $result = $this->callProcessLoginRequest();
+
+        $this->assertNull($result);
+    }
+
+    private function createUser()
+    {
+        $user = new User();
+
+        $user->id = self::$faker->randomDigit();
+        $user->name = self::$faker->name();
+        $user->email = self::$faker->email();
+        $user->user_id = self::$faker->uuid();
+
+        return $user;
+    }
+
+    private function callProcessLoginRequest()
+    {
+        $mockRequest = Mockery::mock(Request::class);
+        $mockRequest->shouldReceive('query')->with('access_token')->once()->andReturn(self::$faker->uuid());
+
+        $result = $this->amazonLoginAuthenticator->processLoginRequest($mockRequest);
+
+        return $result;
+    }
+
+    private function givenValidCurlRequests($token, $timesInitCalled, $timesSetOptionCalled, $timesSecondExecuteIsCalled, $timesClosedIsCalled)
+    {
+        $userId = self::$faker->uuid;
+
+        $accessTokenResultJson =
+        '{
+            "aud": "' . $token . '",
+            "user_id": "' . $userId . '",
+            "iss": "' . self::$faker->url() . '",
+            "exp": ' . self::$faker->randomNumber() . ',
+            "app_id": "amzn1.application.' . dechex(self::$faker->randomNumber()) . '",
+            "iat": ' . self::$faker->randomNumber() . '
+        }';
+
+        $userProfileResultJson =
+        '{
+            "user_id": "' . $userId . '",
+            "name": "' . self::$faker->name() . '",
+            "email": "' . self::$faker->email() . '"
+        }';
+
+        $this->mockCurlRequest
+            ->shouldReceive('init')->withAnyArgs()->times($timesInitCalled)
+            ->shouldReceive('setOption')->withAnyArgs()->times($timesSetOptionCalled)
+            ->shouldReceive('execute')->once()->andReturn($accessTokenResultJson)
+            ->shouldReceive('execute')->times($timesSecondExecuteIsCalled)->andReturn($userProfileResultJson)
+            ->shouldReceive('close')->times($timesClosedIsCalled);
+    }
+
+    private function givenBadAccessTokenCurlRequests($curlReturnValue, $timesInitCalled, $timesSetOptionCalled, $timesClosedIsCalled)
+    {
+        $this->mockCurlRequest
+            ->shouldReceive('init')->withAnyArgs()->times($timesInitCalled)
+            ->shouldReceive('setOption')->withAnyArgs()->times($timesSetOptionCalled)
+            ->shouldReceive('execute')->once()->andReturn($curlReturnValue)
+            ->shouldReceive('close')->times($timesClosedIsCalled);
+    }
+}

--- a/tests/unit/controller/web/LoginControllerTest.php
+++ b/tests/unit/controller/web/LoginControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Controller\Web;
 
-use App\Http\Wrappers\ICurlRequest;
+use App\Http\Authentication\ILoginAuthenticator;
 use App\User;
 use Mockery;
 use Tests\Unit\Controller\Common\ControllerTestCase;
@@ -32,33 +32,26 @@ class LoginControllerTest extends ControllerTestCase
 
     public function testIndex_GivenUserLoggedIn_RedirectedToDevices()
     {
-        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text])->call('GET', '/');
+        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text()])->call('GET', '/');
         
         $this->assertRedirectedToRouteWith302($response, '/devices');
     }
 
-    public function testLogin_GivenAccessTokenNotSet_Returns401()
+    public function testLogin_GivenEmptyRequest_Returns401()
     {
-        $response = $this->get('/login', ['access_token' => '']);
-
-        $response->assertStatus(401);
-    }
-
-    public function testLogin_GivenBadAccessToken_Returns401()
-    {
-        $this->givenCurlRequests(self::$faker->uuid(), 1, 1, 0, 1);
-
-        $response = $this->call('GET', '/login', ['access_token' => self::$faker->uuid]);
+        $response = $this->call('GET', '/login');
 
         $response->assertStatus(401);
     }
 
     public function testLogin_GivenUserLoggedIn_RedirectToDevices()
     {
-        $this->givenCurlRequests(env('AMAZON_TOKEN'), 2, 3, 1, 2);
-        $this->givenSingleUserExists();
+        $mockLoginAuthenticator = Mockery::mock(ILoginAuthenticator::class);
+        $mockLoginAuthenticator->shouldReceive('processLoginRequest')->withAnyArgs()->once()->andReturn(new User());
 
-        $response = $this->call('GET', '/login', ['access_token' => self::$faker->uuid]);
+        $this->app->instance(ILoginAuthenticator::class, $mockLoginAuthenticator);
+
+        $response = $this->call('GET', '/login');
 
         $this->assertRedirectedToRouteWith302($response, '/devices');
     }
@@ -79,56 +72,15 @@ class LoginControllerTest extends ControllerTestCase
 
     public function testLogout_GivenUserLoggedIn_RedirectToIndex()
     {
-        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text])->get('/logout');
+        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text()])->get('/logout');
 
         $this->assertRedirectedToRouteWith302($response, '/');
     }
 
     public function testLogout_GivenUserLoggedIn_SessionCleared()
     {
-        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text])->get('/logout');
+        $response = $this->withSession([env('SESSION_USER_ID') => self::$faker->text()])->get('/logout');
 
         $response->assertSessionMissing(env('SESSION_USER_ID'));
-    }
-
-    private function givenCurlRequests($token, $timesInitCalled, $timesSetOptionCalled, $timesSecondExecuteIsCalled, $timesClosedIsCalled)
-    {
-        $userId = self::$faker->uuid();
-
-        $accessTokenResultJson =
-        '{
-            "aud": "' . $token . '",
-            "user_id": "' . $userId . '",
-            "iss": "' . self::$faker->url() . '",
-            "exp": ' . self::$faker->randomNumber() . ',
-            "app_id": "amzn1.application.' . dechex(self::$faker->randomNumber()) . '",
-            "iat": ' . self::$faker->randomNumber() . '
-        }';
-
-        $userProfileResultJson =
-        '{
-            "user_id": "' . $userId . '",
-            "name": "' . self::$faker->name() . '",
-            "email": "' . self::$faker->email() . '"
-        }';
-
-        $mockCurlRequest = Mockery::mock(ICurlRequest::class);
-        $mockCurlRequest
-            ->shouldReceive('init')->withAnyArgs()->times($timesInitCalled)
-            ->shouldReceive('setOption')->withAnyArgs()->times($timesSetOptionCalled)
-            ->shouldReceive('execute')->once()->andReturn($accessTokenResultJson)
-            ->shouldReceive('execute')->times($timesSecondExecuteIsCalled)->andReturn($userProfileResultJson)
-            ->shouldReceive('close')->times($timesClosedIsCalled);
-        $this->app->instance(ICurlRequest::class, $mockCurlRequest);
-    }
-
-    private function givenSingleUserExists()
-    {
-        $mockUserTable = Mockery::mock(User::class)->makePartial();
-        $mockUserTable
-            ->shouldReceive('where')->withAnyArgs()->once()->andReturn(Mockery::self())
-            ->shouldReceive('first')->once()
-            ->shouldReceive('add')->withAnyArgs()->once()->andReturn(Mockery::self());
-        $this->app->instance(User::class, $mockUserTable);
     }
 }


### PR DESCRIPTION
The `LoginController` had a rigid dependency on Amazon.  To take advantage of dependency injection I inverted controller by creating a new interface called `ILoginAuthenticator` that the `LoginController` now depends on (instead of performing curl requests against Amazon directly).  There is currently only one implementation of `ILoginAuthenticator` called `AmazonLoginAuthenticator`, but it would be easy now to add the ability to login from other sources too (i.e. Google and/or Facebook) by just swapping dependencies.  This drastically simplified the `LoginController`.  The tests are a lot more logical now too.