### PR TITLE
Fix for Travis building PR's twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ addons:
   code_climate:
     repo_token: $CODECLIMATE_REPO_TOKEN
 
+branches:
+  only:
+    - master
+
 before_script:
   - composer self-update
   - composer install --prefer-dist


### PR DESCRIPTION
Travis is building a PR twice (for both a push and a PR trigger), this fix will make it just build once when opening a PR.

Inspired by: http://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda