### PR TITLE
Implementing the API for controlling devices

### DIFF
--- a/app/Http/Authentication/ILoginAuthenticator.php
+++ b/app/Http/Authentication/ILoginAuthenticator.php
@@ -7,4 +7,6 @@ use Illuminate\Http\Request;
 interface ILoginAuthenticator
 {
     public function processLoginRequest(Request $request);
+
+    public function processApiLoginRequest(Request $request);
 }

--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Device;
+use App\Http\Controllers\Common\Controller;
+use App\User;
+use Illuminate\Http\Request;
+
+class DevicesController extends Controller
+{
+    private $deviceModel;
+    private $userModel;
+
+    public function __construct(Device $deviceModel, User $userModel)
+    {
+        $this->middleware('apiAuthenticator');
+
+        $this->deviceModel = $deviceModel;
+        $this->userModel = $userModel;
+    }
+
+    public function index(Request $request)
+    {
+        $userId = $request->get('currentUserId');
+
+        $devicesForCurrentUser = $this->currentUser($userId)->devices;
+
+        $response = [
+            'header' => $this->createHeader($request, 'DiscoverAppliancesResponse', 'Alexa.ConnectedHome.Discovery'),
+            'payload' => [
+                'discoveredAppliances' => $this->buildAppliancesJson($devicesForCurrentUser)
+            ]
+        ];
+
+        return response()->json($response);
+    }
+
+    public function turnOn(Request $request)
+    {
+        $response = $this->handleControlRequest($request, 'TurnOnConfirmation');
+
+        return $response;
+    }
+
+    public function turnOff(Request $request)
+    {
+        $response = $this->handleControlRequest($request, 'TurnOffConfirmation');
+
+        return $response;
+    }
+
+    private function handleControlRequest(Request $request, $responseName)
+    {
+        $userId = $request->get('currentUserId');
+        $deviceId = $request->input('id');
+
+        $doesUserOwnDevice = $this->currentUser($userId)->doesUserOwnDevice($deviceId);
+
+        if (!$doesUserOwnDevice) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $response = [
+            'header' => $this->createHeader($request, $responseName, 'Alexa.ConnectedHome.Control'),
+            'payload' => (object)[]
+        ];
+
+        return response()->json($response);
+    }
+
+    private function buildAppliancesJson($devicesForCurrentUser)
+    {
+        $actions = ['turnOn', 'turnOff'];
+
+        $appliances = [];
+
+        for ($i = 0; $i < count($devicesForCurrentUser); $i++) {
+            $appliance = [
+                'actions' => $actions,
+                'additionalApplianceDetails' => (object)[],
+                'applianceId' => $devicesForCurrentUser[$i]->id,
+                'friendlyName' => $devicesForCurrentUser[$i]->name,
+                'friendlyDescription' => $devicesForCurrentUser[$i]->description,
+                'isReachable' => true,
+                'manufacturerName' => 'N/A',
+                'modelName' => 'N/A',
+                'version' => 'N/A'
+            ];
+
+            array_push($appliances, $appliance);
+        }
+
+        return $appliances;
+    }
+
+    private function createHeader(Request $request, $responseName, $namespace)
+    {
+        $messageId = $request->header('Message-Id');
+
+        $header = [
+            'messageId' => $messageId,
+            'name' => $responseName,
+            'namespace' => $namespace,
+            'payloadVersion' => '2'
+        ];
+
+        return $header;
+    }
+
+    private function currentUser($userId)
+    {
+        $currentUser = $this->userModel->where('user_id', $userId)->first();
+
+        return $currentUser;
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,6 +49,7 @@ class Kernel extends HttpKernel
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'apiAuth' => \App\Http\Middleware\ApiAuthenticator::class
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -50,6 +50,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'apiAuth' => \App\Http\Middleware\ApiAuthenticator::class
+        'apiAuthenticator' => \App\Http\Middleware\ApiAuthenticator::class
     ];
 }

--- a/app/Http/Middleware/ApiAuthenticator.php
+++ b/app/Http/Middleware/ApiAuthenticator.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Http\Authentication\ILoginAuthenticator;
 use Closure;
+use Illuminate\Http\Request;
 
 class ApiAuthenticator
 {
@@ -14,12 +15,12 @@ class ApiAuthenticator
         $this->loginAuthenticator = $loginAuthenticator;
     }
 
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
         $user = $this->loginAuthenticator->processApiLoginRequest($request);
 
         if ($user === null) {
-            abort(401, 'Unauthorized');
+            return response()->json(['error' => 'Unauthorized'], 401);
         }
 
         $request->attributes->add(['currentUserId' => $user->user_id]);

--- a/app/Http/Middleware/ApiAuthenticator.php
+++ b/app/Http/Middleware/ApiAuthenticator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Authentication\ILoginAuthenticator;
+use Closure;
+
+class ApiAuthenticator
+{
+    private $loginAuthenticator;
+
+    public function __construct(ILoginAuthenticator $loginAuthenticator)
+    {
+        $this->loginAuthenticator = $loginAuthenticator;
+    }
+
+    public function handle($request, Closure $next)
+    {
+        $user = $this->loginAuthenticator->processApiLoginRequest($request);
+
+        if ($user === null) {
+            abort(401, 'Unauthorized');
+        }
+
+        $request->attributes->add(['currentUserId' => $user->user_id]);
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,3 +1,5 @@
 <?php
 
-Route::resource('/devices', 'API\DevicesController');//->middleware('apiAuth');
+Route::resource('/devices', 'API\DevicesController');
+Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn');
+Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,18 +1,3 @@
 <?php
 
-use Illuminate\Http\Request;
-
-/*
-|--------------------------------------------------------------------------
-| API Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
-|
-*/
-
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:api');
+Route::resource('/devices', 'API\DevicesController');//->middleware('apiAuth');

--- a/tests/unit/controller/api/DeviceControllerTest.php
+++ b/tests/unit/controller/api/DeviceControllerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests\Unit\Controller\Api;
+
+use App\Http\Authentication\ILoginAuthenticator;
+use App\User;
+use Mockery;
+use Tests\Unit\Controller\Common\DeviceControllerTestCase;
+
+class DeviceControllerTest extends DeviceControllerTestCase
+{
+    private $messageId;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->messageId = self::$faker->uuid;
+    }
+
+    public function testIndex_GivenUserExistsWithNoDevices_ReturnsJsonResponse()
+    {
+        $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+
+        $response = $this->callDevices();
+
+        $this->assertDiscoverAppliancesResponseWithoutDevice($response);
+    }
+
+    public function testIndex_GivenUserExistsWithDevices_ReturnsJsonResponse()
+    {
+        $device1Name = self::$faker->word();
+        $device2Name = self::$faker->word();
+        $device3Name = self::$faker->word();
+
+        $this->givenSingleUserExistsWithDevicesRegisteredWithApi($device1Name, $device2Name, $device3Name);
+
+        $response = $this->callDevices();
+
+        $this->assertDiscoverAppliancesResponse($response, $device1Name, $device2Name, $device3Name);
+    }
+
+    public function testIndex_GivenUserDoesNotExist_Returns401()
+    {
+        $response = $this->getJson('/api/devices', [
+            'HTTP_Authorization' => 'Bearer ' . self::$faker->uuid(),
+            'HTTP_Message_Id' => $this->messageId
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function testTurnOn_GivenUserExistsWithDevice_ReturnsJsonResponse()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $device = $this->createDevice(self::$faker->word(), $user);
+
+        $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
+
+        $response = $this->callControl('turnon', $device->id);
+
+        $this->assertControlConfirmation($response);
+    }
+
+    public function testTurnOn_GivenUserExistsWithNoDevices_Returns401()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $deviceId = self::$faker->randomDigit();
+
+        $this->givenDoesUserOwnDevice($user, $deviceId, false);
+
+        $response = $this->callControl('turnon', $deviceId);
+
+        $response->assertStatus(401);
+    }
+
+    public function testTurnOff_GivenUserExistsWithDevice_ReturnsJsonResponse()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $device = $this->createDevice(self::$faker->word(), $user);
+
+        $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
+
+        $response = $this->callControl('turnoff', $device->id);
+
+        $this->assertControlConfirmation($response);
+    }
+
+    public function testTurnOff_GivenUserExistsWithNoDevices_Returns401()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $deviceId = self::$faker->randomDigit();
+
+        $this->givenDoesUserOwnDevice($user, $deviceId, false);
+
+        $response = $this->callControl('turnoff', $deviceId);
+
+        $response->assertStatus(401);
+    }
+
+    private function givenSingleUserExistsWithNoDevicesRegisteredWithApi()
+    {
+        $user = $this->givenSingleUserExists();
+
+        $this->registerUserWithApi($user);
+
+        $mockUserTable = Mockery::mock(User::class);
+        $mockUserTable
+            ->shouldReceive('where')->with('user_id', $user->user_id)->andReturn(Mockery::self())
+            ->shouldReceive('first')->andReturn(Mockery::self())
+            ->shouldReceive('getAttribute')->with('devices')->andReturn([]);
+
+        $this->app->instance(User::class, $mockUserTable);
+
+        return $user;
+    }
+
+    private function givenSingleUserExistsWithDevicesRegisteredWithApi($device1Name, $device2Name, $device3Name)
+    {
+        $user = $this->givenSingleUserExistsWithDevices($device1Name, $device2Name, $device3Name);
+
+        $this->registerUserWithApi($user);
+    }
+
+    private function registerUserWithApi(User $user)
+    {
+        $mockRequest = Mockery::mock(ILoginAuthenticator::class);
+        $mockRequest->shouldReceive('processApiLoginRequest')->withAnyArgs()->once()->andReturn($user);
+        $this->app->instance(ILoginAuthenticator::class, $mockRequest);
+    }
+
+    private function callDevices()
+    {
+        $response = $this->getJson('/api/devices', [
+            'HTTP_Authorization' => 'Bearer ' . self::$faker->uuid(),
+            'HTTP_Message_Id' => $this->messageId
+        ]);
+
+        return $response;
+    }
+
+    private function callControl($action, $deviceId)
+    {
+        $response = $this->postJson('/api/devices/' . $action, ['id' => $deviceId], [
+            'HTTP_Authorization' => 'Bearer ' . self::$faker->uuid(),
+            'HTTP_Message_Id' => $this->messageId
+        ]);
+
+        return $response;
+    }
+
+    private function assertDiscoverAppliancesResponseWithoutDevice($response)
+    {
+        $response->assertJsonStructure([
+            'header' => [
+                'messageId',
+                'name',
+                'namespace',
+                'payloadVersion'
+            ],
+            'payload' => [
+                'discoveredAppliances' => []
+            ]
+        ]);
+
+        $response->assertSee($this->messageId);
+    }
+
+    private function assertDiscoverAppliancesResponse($response, $device1Name, $device2Name, $device3Name)
+    {
+        $response->assertJsonStructure([
+            'header' => [
+                'messageId',
+                'name',
+                'namespace',
+                'payloadVersion'
+            ],
+            'payload' => [
+                'discoveredAppliances' => [
+                    [
+                        'actions',
+                        'additionalApplianceDetails',
+                        'applianceId',
+                        'friendlyName',
+                        'friendlyDescription',
+                        'isReachable',
+                        'manufacturerName',
+                        'modelName',
+                        'version'
+                    ],
+                    [
+                        'actions',
+                        'additionalApplianceDetails',
+                        'applianceId',
+                        'friendlyName',
+                        'friendlyDescription',
+                        'isReachable',
+                        'manufacturerName',
+                        'modelName',
+                        'version'
+                    ],
+                    [
+                        'actions',
+                        'additionalApplianceDetails',
+                        'applianceId',
+                        'friendlyName',
+                        'friendlyDescription',
+                        'isReachable',
+                        'manufacturerName',
+                        'modelName',
+                        'version'
+                    ]
+                ]
+            ]
+        ]);
+
+        $response->assertSee($this->messageId);
+        $response->assertSee($device1Name);
+        $response->assertSee($device2Name);
+        $response->assertSee($device3Name);
+    }
+
+    private function assertControlConfirmation($response)
+    {
+        $response->assertJsonStructure([
+            'header' => [
+                'messageId',
+                'name',
+                'namespace',
+                'payloadVersion'
+            ],
+            'payload' => []
+        ]);
+
+        $response->assertSee($this->messageId);
+    }
+}

--- a/tests/unit/controller/common/DeviceControllerTestCase.php
+++ b/tests/unit/controller/common/DeviceControllerTestCase.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Controller\Common;
+
+use App\Device;
+use App\User;
+use Mockery;
+
+class DeviceControllerTestCase extends ControllerTestCase
+{
+    protected function givenSingleUserExists()
+    {
+        $user = $this->createUser(self::$faker->uuid());
+
+        $mockUserTable = Mockery::mock(User::class);
+        $mockUserTable
+            ->shouldReceive('where')->with('user_id', $user->user_id)->andReturn(Mockery::self())
+            ->shouldReceive('first')->andReturn($user);
+
+        $this->app->instance(User::class, $mockUserTable);
+
+        return $user;
+    }
+
+    protected function givenSingleUserExistsWithDevices($device1Name, $device2Name, $device3Name)
+    {
+        $userId = self::$faker->uuid();
+
+        $user = $this->createUser($userId);
+
+        $collection = new Device();
+
+        $devices = $collection->newCollection(
+            [
+                $this->createDevice($device1Name, $userId),
+                $this->createDevice($device2Name, $userId),
+                $this->createDevice($device3Name, $userId)
+            ]
+        );
+
+        $mockUserRecord = Mockery::mock(User::class)->makePartial();
+        $mockUserRecord->shouldReceive('getAttribute')->with('devices')->once()->andReturn($devices);
+
+        $this->mockUserTable($mockUserRecord, $userId);
+
+        return $user;
+    }
+
+    protected function givenDeviceIsRegisteredToUser($device, $userId)
+    {
+        $collection = new Device();
+
+        $deviceCollection = $collection->newCollection([$device]);
+
+        $mockUserRecord = Mockery::mock(User::class)->makePartial();
+        $mockUserRecord->shouldReceive('getAttribute')->with('devices')->once()->andReturn($deviceCollection);
+
+        $this->mockUserTable($mockUserRecord, $userId);
+    }
+
+    protected function givenSingleUserExistsWithSingleDevice()
+    {
+        $userId = self::$faker->uuid();
+
+        $collection = new Device();
+
+        $device = $this->createDevice(self::$faker->name(), $userId);
+
+        $devices = $collection->newCollection([$device]);
+
+        $mockUserRecord = Mockery::mock(User::class)->makePartial();
+        $mockUserRecord->shouldReceive('getAttribute')->with('devices')->once()->andReturn($devices);
+
+        $this->mockUserTable($mockUserRecord, $userId);
+
+        return $device;
+    }
+
+    protected function createUser($userId)
+    {
+        $user = new User();
+
+        $user->id = self::$faker->randomDigit();
+        $user->name = self::$faker->name();
+        $user->email = self::$faker->email();
+        $user->user_id = $userId;
+
+        return $user;
+    }
+
+    protected function mockUserTable($mockUserRecord, $userId)
+    {
+        $mockUserTable = Mockery::mock(User::class);
+        $mockUserTable
+            ->shouldReceive('where')->with('user_id', $userId)->once()->andReturn(Mockery::self())
+            ->shouldReceive('first')->once()->andReturn($mockUserRecord);
+
+        $this->app->instance(User::class, $mockUserTable);
+    }
+
+    protected function createDevice($deviceName, $userId)
+    {
+        $device = new Device([
+            'id' => self::$faker->randomDigit(),
+            'name' => $deviceName,
+            'description' => self::$faker->sentence(),
+            'user_id' => $userId
+        ]);
+
+        return $device;
+    }
+
+    protected function givenDoesUserOwnDevice($user, $deviceId, $doesUserOwnDevice)
+    {
+        $mockUserRecord = Mockery::mock(User::class);
+        $mockUserRecord->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);
+
+        $this->mockUserTable($mockUserRecord, $user->user_id);
+    }
+}

--- a/tests/unit/controller/web/DeviceControllerTest.php
+++ b/tests/unit/controller/web/DeviceControllerTest.php
@@ -6,9 +6,9 @@ use App\Device;
 use App\RFDevice;
 use App\User;
 use Mockery;
-use Tests\Unit\Controller\Common\ControllerTestCase;
+use Tests\Unit\Controller\Common\DeviceControllerTestCase;
 
-class DeviceControllerTest extends ControllerTestCase
+class DeviceControllerTest extends DeviceControllerTestCase
 {
     public function testDevices_GivenUserNotLoggedIn_RedirectToIndex()
     {
@@ -101,44 +101,6 @@ class DeviceControllerTest extends ControllerTestCase
         $this->assertRedirectedToRouteWith302($response, '/devices');
     }
 
-    private function givenSingleUserExists()
-    {
-        $user = $this->createUser(self::$faker->uuid());
-
-        $mockUserTable = Mockery::mock(User::class);
-        $mockUserTable
-            ->shouldReceive('where')->with('user_id', $user->user_id)->andReturn(Mockery::self())
-            ->shouldReceive('first')->andReturn($user);
-
-        $this->app->instance(User::class, $mockUserTable);
-
-        return $user;
-    }
-
-    private function givenSingleUserExistsWithDevices($device1Name, $device2Name, $device3Name)
-    {
-        $userId = self::$faker->uuid();
-
-        $user = $this->createUser($userId);
-
-        $collection = new Device();
-
-        $devices = $collection->newCollection(
-            [
-                new Device(['name' => $device1Name, 'user_id' => $userId]),
-                new Device(['name' => $device2Name, 'user_id' => $userId]),
-                new Device(['name' => $device3Name, 'user_id' => $userId])
-            ]
-        );
-
-        $mockUserRecord = Mockery::mock(User::class)->makePartial();
-        $mockUserRecord->shouldReceive('getAttribute')->with('devices')->once()->andReturn($devices);
-
-        $this->mockUserTable($mockUserRecord, $userId);
-
-        return $user;
-    }
-
     private function addDeviceForUser($userId, $deviceName)
     {
         $mockDeviceModel = Mockery::mock(Device::class);
@@ -159,35 +121,5 @@ class DeviceControllerTest extends ControllerTestCase
             ]);
 
         return $response;
-    }
-
-    private function createUser($userId)
-    {
-        $user = new User();
-
-        $user->id = self::$faker->randomDigit();
-        $user->name = self::$faker->name();
-        $user->email = self::$faker->email();
-        $user->user_id = $userId;
-
-        return $user;
-    }
-
-    private function givenDoesUserOwnDevice($user, $deviceId, $doesUserOwnDevice)
-    {
-        $mockUserRecord = Mockery::mock(User::class);
-        $mockUserRecord->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);
-
-        $this->mockUserTable($mockUserRecord, $user->user_id);
-    }
-
-    private function mockUserTable($mockUserRecord, $userId)
-    {
-        $mockUserTable = Mockery::mock(User::class);
-        $mockUserTable
-            ->shouldReceive('where')->with('user_id', $userId)->once()->andReturn(Mockery::self())
-            ->shouldReceive('first')->once()->andReturn($mockUserRecord);
-
-        $this->app->instance(User::class, $mockUserTable);
     }
 }


### PR DESCRIPTION
This is pretty much just a reimplementation of the existing API before the port to Laravel.  Some aspects that have changed from the F3 version of the API:

-User authentication is handled in the middleware layer, this way the `API/DevicesController` doesn't have a dependency on the `LoginController`
-Uses callback functions to generate list of devices
-Added function to `ILoginAuthenticator` to handle verifying a user from the API