### PR TITLE
Add flash messages for device actions

### DIFF
--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -47,16 +47,26 @@ class DevicesController extends Controller
         $newDeviceId = $this->deviceModel->add($name, $description, $type, $currentUserId)->id;
         $this->rfDeviceModel->add($onCode, $offCode, $pulseLength, $newDeviceId);
 
+        $request->session()->flash('alert-success', "Device '$name' was successfully added!");
+
         return redirect()->route('devices');
     }
 
-    public function delete($deviceId)
+    public function delete(Request $request, $deviceId)
     {
         $doesUserOwnDevice = $this->currentUser()->doesUserOwnDevice($deviceId);
 
-        if ($doesUserOwnDevice) {
-            $this->deviceModel->destroy($deviceId);
+        if (!$doesUserOwnDevice) {
+            $request->session()->flash('alert-danger', 'Error deleting device!');
+
+            return redirect()->route('devices');
         }
+
+        $name = $this->deviceModel->find($deviceId)->name;
+
+        $this->deviceModel->destroy($deviceId);
+
+        $request->session()->flash('alert-success', "Device '$name' was successfully deleted!");
 
         return redirect()->route('devices');
     }

--- a/resources/views/devices.blade.php
+++ b/resources/views/devices.blade.php
@@ -41,6 +41,8 @@
                             </ul>
                         </div>
                     </nav>
+                    @component('partials.flash-messages')
+                    @endcomponent
                     <div class="panel panel-default">
                         <div class="panel-heading">
                              <div class="panel-title">

--- a/resources/views/partials/flash-messages.blade.php
+++ b/resources/views/partials/flash-messages.blade.php
@@ -1,0 +1,31 @@
+<div class="flash-message">
+    @foreach (['danger', 'warning', 'success', 'info'] as $message)
+        @if (Session::has('alert-' . $message))
+            @if ($message == 'danger')
+                <div class="alert alert-danger" role="alert">
+                    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                    <span class="sr-only">Error:</span>
+                    {{ Session::get('alert-' . $message) }} <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                </div>
+            @elseif ($message == 'warning')
+                <div class="alert alert-warning" role="alert">
+                    <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+                    <span class="sr-only">Warning:</span>
+                    {{ Session::get('alert-' . $message) }} <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                </div>
+            @elseif ($message == 'success')
+                <div class="alert alert-success" role="alert">
+                    <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                    <span class="sr-only">Success:</span>
+                    {{ Session::get('alert-' . $message) }} <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                </div>
+            @elseif ($message == 'info')
+                <div class="alert alert-info" role="alert">
+                    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                    <span class="sr-only">Info:</span>
+                    {{ Session::get('alert-' . $message) }} <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                </div>
+            @endif
+        @endif
+    @endforeach
+</div>


### PR DESCRIPTION
-Now when a user adds or deletes a device, they'll see a confirmation message at the top of the page
-If a user tries to delete a device they do not own, they'll see an error message
-I also renamed some related test cases to be more clear