### PR TITLE
Implemented MQTT message passing for the web and API

### DIFF
--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Device;
 use App\Http\Controllers\Common\Controller;
+use App\Http\Globals\DeviceActions;
 use App\User;
 use Illuminate\Http\Request;
 
@@ -38,14 +39,14 @@ class DevicesController extends Controller
 
     public function turnOn(Request $request)
     {
-        $response = $this->handleControlRequest($request, 'TurnOnConfirmation');
+        $response = $this->handleControlRequest($request, DeviceActions::TURN_ON, 'TurnOnConfirmation');
 
         return $response;
     }
 
     public function turnOff(Request $request)
     {
-        $response = $this->handleControlRequest($request, 'TurnOffConfirmation');
+        $response = $this->handleControlRequest($request, DeviceActions::TURN_OFF, 'TurnOffConfirmation');
 
         return $response;
     }
@@ -71,7 +72,7 @@ class DevicesController extends Controller
 
     private function buildAppliancesJson($devicesForCurrentUser)
     {
-        $actions = ['turnOn', 'turnOff'];
+        $actions = [DeviceActions::TURN_ON, DeviceActions::TURN_OFF];
 
         $appliances = [];
 

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Web;
 
 use App\Device;
 use App\Http\Controllers\Common\Controller;
+use App\Http\Globals\FlashMessageLevels;
 use App\RFDevice;
 use App\User;
 use DB;
@@ -47,7 +48,7 @@ class DevicesController extends Controller
         $newDeviceId = $this->deviceModel->add($name, $description, $type, $currentUserId)->id;
         $this->rfDeviceModel->add($onCode, $offCode, $pulseLength, $newDeviceId);
 
-        $request->session()->flash('alert-success', "Device '$name' was successfully added!");
+        $request->session()->flash(FlashMessageLevels::SUCCESS, "Device '$name' was successfully added!");
 
         return redirect()->route('devices');
     }
@@ -57,7 +58,7 @@ class DevicesController extends Controller
         $doesUserOwnDevice = $this->currentUser()->doesUserOwnDevice($id);
 
         if (!$doesUserOwnDevice) {
-            $request->session()->flash('alert-danger', 'Error deleting device!');
+            $request->session()->flash(FlashMessageLevels::DANGER, 'Error deleting device!');
 
             return redirect()->route('devices');
         }
@@ -66,7 +67,7 @@ class DevicesController extends Controller
 
         $this->deviceModel->destroy($id);
 
-        $request->session()->flash('alert-success', "Device '$name' was successfully deleted!");
+        $request->session()->flash(FlashMessageLevels::SUCCESS, "Device '$name' was successfully deleted!");
 
         return redirect()->route('devices');
     }

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -52,9 +52,9 @@ class DevicesController extends Controller
         return redirect()->route('devices');
     }
 
-    public function delete(Request $request, $deviceId)
+    public function delete(Request $request, $id)
     {
-        $doesUserOwnDevice = $this->currentUser()->doesUserOwnDevice($deviceId);
+        $doesUserOwnDevice = $this->currentUser()->doesUserOwnDevice($id);
 
         if (!$doesUserOwnDevice) {
             $request->session()->flash('alert-danger', 'Error deleting device!');
@@ -62,9 +62,9 @@ class DevicesController extends Controller
             return redirect()->route('devices');
         }
 
-        $name = $this->deviceModel->find($deviceId)->name;
+        $name = $this->deviceModel->find($id)->name;
 
-        $this->deviceModel->destroy($deviceId);
+        $this->deviceModel->destroy($id);
 
         $request->session()->flash('alert-success', "Device '$name' was successfully deleted!");
 

--- a/app/Http/Globals/DeviceActions.php
+++ b/app/Http/Globals/DeviceActions.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Http\Globals;
+
+abstract class DeviceActions
+{
+    const TURN_ON = 'turnOn';
+    const TURN_OFF = 'turnOff';
+}

--- a/app/Http/Globals/FlashMessageLevels.php
+++ b/app/Http/Globals/FlashMessageLevels.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Globals;
+
+abstract class FlashMessageLevels
+{
+    const DANGER = 'alert-danger';
+    const WARNING = 'alert-warning';
+    const SUCCESS = 'alert-success';
+    const INFO = 'alert-info';
+}

--- a/app/Http/MQTT/MessagePublisher.php
+++ b/app/Http/MQTT/MessagePublisher.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\MQTT;
+
+use LibMQTT\Client;
+
+class MessagePublisher
+{
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function publish($userId, $deviceId, $action)
+    {
+        if (!$this->client->connect()) {
+            return false;
+        }
+
+        $this->client->publish("RoboHome/$userId/$deviceId", $action, 0);
+        $this->client->close();
+
+        return true;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use LibMQTT\Client;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -10,5 +11,13 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind('App\Http\Authentication\ILoginAuthenticator', 'App\Http\Authentication\AmazonLoginAuthenticator');
         $this->app->bind('App\Http\Wrappers\ICurlRequest', 'App\Http\Wrappers\CurlRequest');
+        $this->app->bind('LibMQTT\Client', function () {
+            $maxClientIdLength = 23;
+            $clientId = substr(str_shuffle(MD5(microtime())), 0, $maxClientIdLength);
+            $client = new Client(env('MQTT_SERVER'), env('MQTT_PORT'), $clientId);
+            $client->setAuthDetails(env('MQTT_USER'), env('MQTT_PASSWORD'));
+
+            return $client;
+        });
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -23,6 +23,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Route::pattern('id', '[0-9]+');
+
         parent::boot();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "type": "project",
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.4.*"
+        "laravel/framework": "5.4.*",
+        "mcfish/libmqtt": "^0.3.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ae02637df29130c357f7c2415bf10868",
-    "content-hash": "3805edf83bf06aab06ee34e3e9339408",
+    "hash": "8e7f3c713fb357e050dbd9c5169c7e6b",
+    "content-hash": "a26ca46d38d0ffb6d2a3b8e3aefe7f10",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -327,6 +327,43 @@
                 "storage"
             ],
             "time": "2017-02-09 11:33:58"
+        },
+        {
+            "name": "mcfish/libmqtt",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/McFizh/libMQTT.git",
+                "reference": "225e2efcd4f3ee4496c3b0d603d465766c69e68d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/McFizh/libMQTT/zipball/225e2efcd4f3ee4496c3b0d603d465766c69e68d",
+                "reference": "225e2efcd4f3ee4496c3b0d603d465766c69e68d",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LibMQTT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pekka Harjamäki",
+                    "email": "mcfizh@gmail.com"
+                }
+            ],
+            "description": "MQTT 3.1.1 library for PHP with TLS support",
+            "keywords": [
+                "mqtt",
+                "php"
+            ],
+            "time": "2016-08-01 18:15:34"
         },
         {
             "name": "monolog/monolog",

--- a/resources/views/devices.blade.php
+++ b/resources/views/devices.blade.php
@@ -3,10 +3,11 @@
         <title>RoboHome | Devices</title>
         <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous"></script>
         <script>
-            function toggleOutlet(topic, message) {
-                $.ajax({url: "extensions/MQTTPublisher.php?topic=" + topic + "&message=" + message, success: function(result) {
-                    alert(topic + " was turned " + message);
-                }});
+            function controlDevice(action, id) {
+                $.ajax({
+                    type: "POST",
+                    url: "/devices/" + action + "/" + id
+                });
             }
         </script>
         <!-- Latest compiled and minified CSS -->
@@ -67,8 +68,8 @@
                                         <td class="col-xs-5">{{ $device->name }}</td>
                                         <td class="col-xs-5">
                                             <div class="btn-group" role="group" aria-label="Device Controls">
-                                                <button type="button" class="btn btn-primary" onclick="toggleOutlet('EtekcityOutlet1', 'On');">On</button>
-                                                <button type="button" class="btn btn-primary" onclick="toggleOutlet('EtekcityOutlet1', 'Off');">Off</button>
+                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnon', '{{ $device->id }}');">On</button>
+                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnoff', '{{ $device->id }}');">Off</button>
                                             </div>
                                         </td>
                                     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,4 +6,7 @@ Route::get('/logout', 'Web\LoginController@logout')->name('logout');
 
 Route::get('/devices', 'Web\DevicesController@devices')->name('devices');
 Route::post('/devices/add', 'Web\DevicesController@add')->name('addDevice');
-Route::get('/devices/delete/{deviceId}', 'Web\DevicesController@delete')->name('deleteDevice');
+Route::get('/devices/delete/{id}', 'Web\DevicesController@delete')->name('deleteDevice');
+Route::post('/devices/{action}/{id}', 'Web\DevicesController@handleControlRequest')
+    ->where(['action' => '[a-z]+'])
+    ->name('handleControlRequest');

--- a/tests/unit/controller/api/DeviceControllerTest.php
+++ b/tests/unit/controller/api/DeviceControllerTest.php
@@ -63,6 +63,17 @@ class DeviceControllerTest extends DeviceControllerTestCase
         $this->assertControlConfirmation($response);
     }
 
+    public function testTurnOn_GivenUserExistsWithDevice_CallsPublish()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $device = $this->createDevice(self::$faker->word(), $user);
+
+        $this->mockMessagePublisher();
+        $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
+
+        $this->callControl(DeviceActions::TURN_ON, $device->id);
+    }
+
     public function testTurnOn_GivenUserExistsWithNoDevices_Returns401()
     {
         $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
@@ -85,6 +96,17 @@ class DeviceControllerTest extends DeviceControllerTestCase
         $response = $this->callControl(DeviceActions::TURN_OFF, $device->id);
 
         $this->assertControlConfirmation($response);
+    }
+
+    public function testTurnOff_GivenUserExistsWithDevice_CallsPublish()
+    {
+        $user = $this->givenSingleUserExistsWithNoDevicesRegisteredWithApi();
+        $device = $this->createDevice(self::$faker->word(), $user);
+
+        $this->mockMessagePublisher();
+        $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
+
+        $this->callControl(DeviceActions::TURN_OFF, $device->id);
     }
 
     public function testTurnOff_GivenUserExistsWithNoDevices_Returns401()

--- a/tests/unit/controller/api/DeviceControllerTest.php
+++ b/tests/unit/controller/api/DeviceControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Controller\Api;
 
 use App\Http\Authentication\ILoginAuthenticator;
+use App\Http\Globals\DeviceActions;
 use App\User;
 use Mockery;
 use Tests\Unit\Controller\Common\DeviceControllerTestCase;
@@ -57,7 +58,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
 
         $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
 
-        $response = $this->callControl('turnon', $device->id);
+        $response = $this->callControl(DeviceActions::TURN_ON, $device->id);
 
         $this->assertControlConfirmation($response);
     }
@@ -69,7 +70,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
 
         $this->givenDoesUserOwnDevice($user, $deviceId, false);
 
-        $response = $this->callControl('turnon', $deviceId);
+        $response = $this->callControl(DeviceActions::TURN_ON, $deviceId);
 
         $response->assertStatus(401);
     }
@@ -81,7 +82,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
 
         $this->givenDeviceIsRegisteredToUser($device, $user->user_id);
 
-        $response = $this->callControl('turnoff', $device->id);
+        $response = $this->callControl(DeviceActions::TURN_OFF, $device->id);
 
         $this->assertControlConfirmation($response);
     }
@@ -93,7 +94,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
 
         $this->givenDoesUserOwnDevice($user, $deviceId, false);
 
-        $response = $this->callControl('turnoff', $deviceId);
+        $response = $this->callControl(DeviceActions::TURN_OFF, $deviceId);
 
         $response->assertStatus(401);
     }
@@ -141,7 +142,9 @@ class DeviceControllerTest extends DeviceControllerTestCase
 
     private function callControl($action, $deviceId)
     {
-        $response = $this->postJson('/api/devices/' . $action, ['id' => $deviceId], [
+        $urlValidAction = strtolower($action);
+
+        $response = $this->postJson('/api/devices/' . $urlValidAction, ['id' => $deviceId], [
             'HTTP_Authorization' => 'Bearer ' . self::$faker->uuid(),
             'HTTP_Message_Id' => $this->messageId
         ]);

--- a/tests/unit/controller/common/DeviceControllerTestCase.php
+++ b/tests/unit/controller/common/DeviceControllerTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Controller\Common;
 
 use App\Device;
+use App\Http\MQTT\MessagePublisher;
 use App\User;
 use Mockery;
 
@@ -98,14 +99,29 @@ class DeviceControllerTestCase extends ControllerTestCase
         $this->app->instance(User::class, $mockUserTable);
     }
 
+    protected function mockMessagePublisher($timesPublishIsCalled = 1)
+    {
+        $mockMessagePublisher = Mockery::mock(MessagePublisher::class);
+        $mockMessagePublisher
+            ->shouldReceive('publish')
+            ->withAnyArgs()->times($timesPublishIsCalled)
+            ->andReturn(true);
+
+        $this->app->instance(MessagePublisher::class, $mockMessagePublisher);
+    }
+
     protected function createDevice($deviceName, $userId)
     {
+        Device::unguard();
+
         $device = new Device([
             'id' => self::$faker->randomDigit(),
             'name' => $deviceName,
             'description' => self::$faker->sentence(),
             'user_id' => $userId
         ]);
+
+        Device::reguard();
 
         return $device;
     }
@@ -116,5 +132,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         $mockUserRecord->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);
 
         $this->mockUserTable($mockUserRecord, $user->user_id);
+
+        return $mockUserRecord;
     }
 }

--- a/tests/unit/mqtt/MessagePublisherTest.php
+++ b/tests/unit/mqtt/MessagePublisherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\MQTT;
+
+use App\Http\MQTT\MessagePublisher;
+use LibMQTT\Client;
+use Mockery;
+use Tests\TestCase;
+
+class MessagePublisherTest extends TestCase
+{
+    private $userId;
+    private $deviceId;
+    private $action;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->userId = self::$faker->uuid();
+        $this->deviceId = self::$faker->randomDigit();
+        $this->action = self::$faker->word();
+    }
+
+    public function testPublish_GivenValidConnection_ReturnsTrue()
+    {
+        $topic = "RoboHome/$this->userId/$this->deviceId";
+
+        $mockClient = Mockery::mock(Client::class);
+        $mockClient->shouldReceive('connect')->once()->andReturn(true);
+        $mockClient->shouldReceive('publish')->withArgs([$topic, $this->action, 0])->once();
+        $mockClient->shouldReceive('close')->once();
+
+        $messagePublisher = new MessagePublisher($mockClient);
+
+        $result = $messagePublisher->publish($this->userId, $this->deviceId, $this->action);
+
+        $this->assertTrue($result);
+    }
+
+    public function testPublish_GivenValidConnection_ReturnsFalse()
+    {
+        $mockClient = Mockery::mock(Client::class);
+        $mockClient->shouldReceive('connect')->once()->andReturn(false);
+        $mockClient->shouldReceive('publish')->never();
+        $mockClient->shouldReceive('close')->never();
+
+        $messagePublisher = new MessagePublisher($mockClient);
+
+        $result = $messagePublisher->publish($this->userId, $this->deviceId, $this->action);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
-MQTT will be used to publish messages that a microcontroller will be subscribed to
-Any posted URL with the syntax of `/devices/[action]/[id]` will be considered valid (must be all lowercase, see `web.php` for the validation rules)
-Uses ajax to when the "on" or "off" button is clicked to prevent have to reload the page after a message is published
-MD5 is used to generate a client ID (see `AppServiceProvided.php`). While MD5 is not "secure," in this case cryptographic security isn't intended. Generating a "random" string to prevent a potential collision is important.
-Introduced some new constant "global" classes to handle commonly used values for flash messages and actions a device can perform
-Using https://github.com/McFizh/libMQTT from Composer for MQTT support