### PR TITLE
Added ability to request info about a device through the API

### DIFF
--- a/app/Http/Controllers/API/DeviceInformation/IDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/IDeviceInformation.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Controllers\API\DeviceInformation;
+
+interface IDeviceInformation
+{
+    public function info($deviceId, $action);
+}

--- a/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\API\DeviceInformation;
+
+use App\RFDevice;
+
+class RFDeviceInformation implements IDeviceInformation
+{
+    private $rfDeviceModel;
+
+    public function __construct(RFDevice $rfDeviceModel)
+    {
+        $this->rfDeviceModel = $rfDeviceModel;
+    }
+
+    public function info($deviceId, $action)
+    {
+        $rfDevice = $this->rfDeviceModel->where('device_id', $deviceId)->first();
+
+        $response = null;
+
+        $action = strtolower($action);
+
+        if ($action === 'turnon') {
+            $response = [
+                'code' => $rfDevice->on_code
+            ];
+        } elseif ($action === 'turnoff') {
+            $response = [
+                'code' => $rfDevice->off_code
+            ];
+        }
+
+        if ($response === null) {
+            return response()->json(['error' => "Device does not support action '$action'"], 400);
+        }
+
+        return response()->json($response);
+    }
+}

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Web;
 
 use App\Device;
 use App\Http\Controllers\Common\Controller;
+use App\Http\Globals\DeviceTypes;
 use App\Http\Globals\FlashMessageLevels;
 use App\Http\MQTT\MessagePublisher;
 use App\RFDevice;
@@ -45,7 +46,7 @@ class DevicesController extends Controller
         $onCode = $request->input('onCode');
         $offCode = $request->input('offCode');
         $pulseLength = $request->input('pulseLength');
-        $type = 1;
+        $type = DeviceTypes::RF_DEVICE;
 
         $currentUserId = $this->currentUser()->id;
         $newDeviceId = $this->deviceModel->add($name, $description, $type, $currentUserId)->id;

--- a/app/Http/Globals/DeviceTypes.php
+++ b/app/Http/Globals/DeviceTypes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Globals;
+
+class DeviceTypes
+{
+    const RF_DEVICE = 1;
+    const IR_DEVICE = 2;
+    const WIFI_DEVICE = 3;
+}

--- a/app/Providers/DeviceInformationServiceProvider.php
+++ b/app/Providers/DeviceInformationServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Providers;
+
+use App\Http\Globals\DeviceTypes;
+use Illuminate\Http\Request;
+use Illuminate\Support\ServiceProvider;
+
+class DeviceInformationServiceProvider extends ServiceProvider
+{
+    protected $defer = true;
+
+    public function boot()
+    {
+        $this->app->call([$this, 'registerDeviceInformationTypes']);
+    }
+
+    public function registerDeviceInformationTypes(Request $request)
+    {
+        if (!$request->has('deviceId')) {
+            return;
+        }
+
+        $deviceId = $request->get('deviceId');
+
+        $deviceModel = app('App\Device');
+
+        $device = $deviceModel->find($deviceId);
+
+        if ($device === null) {
+            return;
+        }
+
+        $deviceType = $device->device_type_id;
+
+        $deviceInformationInterface = 'App\Http\Controllers\API\DeviceInformation\IDeviceInformation';
+
+        if ($deviceType === DeviceTypes::RF_DEVICE) {
+            $this->app->bind($deviceInformationInterface, 'App\Http\Controllers\API\DeviceInformation\RFDeviceInformation');
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -773,16 +773,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870"
+                "reference": "28fb243a2b5727774ca309ec2d92da240f1af0dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
-                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
+                "url": "https://api.github.com/repos/symfony/console/zipball/28fb243a2b5727774ca309ec2d92da240f1af0dd",
+                "reference": "28fb243a2b5727774ca309ec2d92da240f1af0dd",
                 "shasum": ""
             },
             "require": {
@@ -832,7 +832,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 14:07:22"
+            "time": "2017-03-06 19:30:27"
         },
         {
             "name": "symfony/css-selector",
@@ -889,16 +889,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9"
+                "reference": "b90c9f91ad8ac37d9f114e369042d3226b34dc1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
-                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b90c9f91ad8ac37d9f114e369042d3226b34dc1a",
+                "reference": "b90c9f91ad8ac37d9f114e369042d3226b34dc1a",
                 "shasum": ""
             },
             "require": {
@@ -942,20 +942,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 16:34:18"
+            "time": "2017-02-18 17:28:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.17",
+            "version": "v2.8.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "74877977f90fb9c3e46378d5764217c55f32df34"
+                "reference": "bb4ec47e8e109c1c1172145732d0aa468d967cd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/74877977f90fb9c3e46378d5764217c55f32df34",
-                "reference": "74877977f90fb9c3e46378d5764217c55f32df34",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bb4ec47e8e109c1c1172145732d0aa468d967cd0",
+                "reference": "bb4ec47e8e109c1c1172145732d0aa468d967cd0",
                 "shasum": ""
             },
             "require": {
@@ -963,7 +963,7 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/config": "^2.0.5|~3.0.0",
                 "symfony/dependency-injection": "~2.6|~3.0.0",
                 "symfony/expression-language": "~2.6|~3.0.0",
                 "symfony/stopwatch": "~2.3|~3.0.0"
@@ -1002,20 +1002,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:30:24"
+            "time": "2017-02-21 08:33:48"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
+                "reference": "92d7476d2df60cd851a3e13e078664b1deb8ce10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
-                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/92d7476d2df60cd851a3e13e078664b1deb8ce10",
+                "reference": "92d7476d2df60cd851a3e13e078664b1deb8ce10",
                 "shasum": ""
             },
             "require": {
@@ -1051,20 +1051,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:32:22"
+            "time": "2017-02-21 09:12:04"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "a90da6dd679605d88c9803a57a6fc1fb7a19a6e0"
+                "reference": "c57009887010eb4e58bfca2970314a5b820b24b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a90da6dd679605d88c9803a57a6fc1fb7a19a6e0",
-                "reference": "a90da6dd679605d88c9803a57a6fc1fb7a19a6e0",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/c57009887010eb4e58bfca2970314a5b820b24b9",
+                "reference": "c57009887010eb4e58bfca2970314a5b820b24b9",
                 "shasum": ""
             },
             "require": {
@@ -1104,20 +1104,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 22:46:52"
+            "time": "2017-03-04 12:23:14"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "4cd0d4bc31819095c6ef13573069f621eb321081"
+                "reference": "bc909e85b8585c9edf043d0fca871308c41bb9b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/4cd0d4bc31819095c6ef13573069f621eb321081",
-                "reference": "4cd0d4bc31819095c6ef13573069f621eb321081",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/bc909e85b8585c9edf043d0fca871308c41bb9b4",
+                "reference": "bc909e85b8585c9edf043d0fca871308c41bb9b4",
                 "shasum": ""
             },
             "require": {
@@ -1186,7 +1186,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 23:59:56"
+            "time": "2017-03-10 18:35:31"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1249,16 +1249,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856"
+                "reference": "68bfa8c83f24c0ac04ea7193bcdcda4519f41892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856",
-                "reference": "0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856",
+                "url": "https://api.github.com/repos/symfony/process/zipball/68bfa8c83f24c0ac04ea7193bcdcda4519f41892",
+                "reference": "68bfa8c83f24c0ac04ea7193bcdcda4519f41892",
                 "shasum": ""
             },
             "require": {
@@ -1294,20 +1294,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 14:07:22"
+            "time": "2017-03-04 12:23:14"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "af464432c177dbcdbb32295113b7627500331f2d"
+                "reference": "d6605f9a5767bc5bc4895e1c762ba93964608aee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/af464432c177dbcdbb32295113b7627500331f2d",
-                "reference": "af464432c177dbcdbb32295113b7627500331f2d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/d6605f9a5767bc5bc4895e1c762ba93964608aee",
+                "reference": "d6605f9a5767bc5bc4895e1c762ba93964608aee",
                 "shasum": ""
             },
             "require": {
@@ -1369,20 +1369,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-01-28 02:37:08"
+            "time": "2017-03-02 15:58:09"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "d6825c6bb2f1da13f564678f9f236fe8242c0029"
+                "reference": "0e1b15ce8fbf3890f4ccdac430ed5e07fdfe0690"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/d6825c6bb2f1da13f564678f9f236fe8242c0029",
-                "reference": "d6825c6bb2f1da13f564678f9f236fe8242c0029",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/0e1b15ce8fbf3890f4ccdac430ed5e07fdfe0690",
+                "reference": "0e1b15ce8fbf3890f4ccdac430ed5e07fdfe0690",
                 "shasum": ""
             },
             "require": {
@@ -1395,7 +1395,7 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~2.8|~3.0",
-                "symfony/intl": "~2.8|~3.0",
+                "symfony/intl": "^2.8.18|^3.2.5",
                 "symfony/yaml": "~2.8|~3.0"
             },
             "suggest": {
@@ -1433,25 +1433,28 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 22:46:52"
+            "time": "2017-03-04 12:23:14"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "cb50260b674ee1c2d4ab49f2395a42e0b4681e20"
+                "reference": "4100f347aff890bc16b0b4b42843b599db257b2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cb50260b674ee1c2d4ab49f2395a42e0b4681e20",
-                "reference": "cb50260b674ee1c2d4ab49f2395a42e0b4681e20",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4100f347aff890bc16b0b4b42843b599db257b2d",
+                "reference": "4100f347aff890bc16b0b4b42843b599db257b2d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "require-dev": {
                 "twig/twig": "~1.20|~2.0"
@@ -1496,7 +1499,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-02-16 22:46:52"
+            "time": "2017-02-20 13:45:48"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -3119,16 +3122,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9f99453e77771e629af8a25eeb0a6c4ed1e19da2"
+                "reference": "741d6d4cd1414d67d48eb71aba6072b46ba740c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9f99453e77771e629af8a25eeb0a6c4ed1e19da2",
-                "reference": "9f99453e77771e629af8a25eeb0a6c4ed1e19da2",
+                "url": "https://api.github.com/repos/symfony/config/zipball/741d6d4cd1414d67d48eb71aba6072b46ba740c2",
+                "reference": "741d6d4cd1414d67d48eb71aba6072b46ba740c2",
                 "shasum": ""
             },
             "require": {
@@ -3171,7 +3174,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-14 16:27:43"
+            "time": "2017-03-01 18:18:25"
         },
         {
             "name": "symfony/dom-crawler",
@@ -3231,16 +3234,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4"
+                "reference": "bc0f17bed914df2cceb989972c3b996043c4da4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
-                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bc0f17bed914df2cceb989972c3b996043c4da4a",
+                "reference": "bc0f17bed914df2cceb989972c3b996043c4da4a",
                 "shasum": ""
             },
             "require": {
@@ -3276,20 +3279,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-08 20:47:33"
+            "time": "2017-03-06 19:30:27"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "9aa0b51889c01bca474853ef76e9394b02264464"
+                "reference": "c5ee0f8650c84b4d36a5f76b3b504233feaabf75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9aa0b51889c01bca474853ef76e9394b02264464",
-                "reference": "9aa0b51889c01bca474853ef76e9394b02264464",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/c5ee0f8650c84b4d36a5f76b3b504233feaabf75",
+                "reference": "c5ee0f8650c84b4d36a5f76b3b504233feaabf75",
                 "shasum": ""
             },
             "require": {
@@ -3325,20 +3328,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:32:22"
+            "time": "2017-02-18 17:28:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.4",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
+                "reference": "093e416ad096355149e265ea2e4cc1f9ee40ab1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
-                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/093e416ad096355149e265ea2e4cc1f9ee40ab1a",
+                "reference": "093e416ad096355149e265ea2e4cc1f9ee40ab1a",
                 "shasum": ""
             },
             "require": {
@@ -3380,7 +3383,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16 22:46:52"
+            "time": "2017-03-07 16:47:02"
         },
         {
             "name": "webmozart/assert",

--- a/config/app.php
+++ b/config/app.php
@@ -176,7 +176,8 @@ return [
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
-        App\Providers\RouteServiceProvider::class
+        App\Providers\RouteServiceProvider::class,
+        App\Providers\DeviceInformationServiceProvider::class
     ],
 
     /*
@@ -224,7 +225,5 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-
     ],
-
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,3 +3,4 @@
 Route::resource('/devices', 'API\DevicesController');
 Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn');
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff');
+Route::post('/devices/info', 'API\DevicesController@info')->name('info');

--- a/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
+++ b/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit\Controller\Api\DeviceInformation;
+
+use App\Http\Controllers\API\DeviceInformation\RFDeviceInformation;
+use App\Http\Globals\DeviceActions;
+use App\RFDevice;
+use Mockery;
+use Tests\TestCase;
+
+class RFDeviceInformationTest extends TestCase
+{
+    private $onCode;
+    private $offCode;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->onCode = self::$faker->randomDigit();
+        $this->offCode = self::$faker->randomDigit();
+    }
+
+    public function testInfo_GivenTurnOnAction_ReturnsJsonResponseWithCorrectOnCode()
+    {
+        $action = DeviceActions::TURN_ON;
+
+        $response = $this->callInfo($action);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertEquals($result['code'], $this->onCode);
+    }
+
+    public function testInfo_GivenTurnOffAction_ReturnsJsonResponseWithCorrectOffCode()
+    {
+        $action = DeviceActions::TURN_OFF;
+
+        $response = $this->callInfo($action);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertEquals($result['code'], $this->offCode);
+    }
+
+    public function testInfo_GivenUnknownAction_Returns400()
+    {
+        $action = self::$faker->word();
+
+        $response = $this->callInfo($action);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertEquals($response->status(), 400);
+        $this->assertEquals($result['error'], "Device does not support action '$action'");
+    }
+
+    private function callInfo($action)
+    {
+        $rfDevice = $this->createRFDevice($this->onCode, $this->offCode);
+        $rfDeviceInformation = $this->givenRFDeviceInformation($rfDevice);
+
+        $response = $rfDeviceInformation->info($rfDevice->device_id, $action);
+
+        return $response;
+    }
+
+    private function givenRFDeviceInformation($rfDevice)
+    {
+        $mockRFDeviceTable = Mockery::mock(RFDevice::class);
+        $mockRFDeviceTable
+            ->shouldReceive('where')->with('device_id', $rfDevice->device_id)->andReturn(Mockery::self())
+            ->shouldReceive('first')->andReturn($rfDevice);
+
+        $rfDeviceInformation = new RFDeviceInformation($mockRFDeviceTable);
+
+        return $rfDeviceInformation;
+    }
+
+    private function createRFDevice($onCode, $offCode)
+    {
+        $rfDevice = new RFDevice();
+
+        $rfDevice->on_code = $onCode;
+        $rfDevice->off_code = $offCode;
+        $rfDevice->pulse_length = self::$faker->randomDigit();
+        $rfDevice->device_id = self::$faker->randomDigit();
+
+        return $rfDevice;
+    }
+}


### PR DESCRIPTION
Created a new API endpoint called `info(Request $request)` that will call a function called `info($deviceId, $action)` to collect information about a device that would be needed by the microcontroller to control a device.  Currently, the only implementation is for RF devices (`RFDeviceInformation`).  However, to support adding other types of devices, I created a new service provider (`DeviceInformationServiceProvider`) which will bind different instances of `IDeviceInformation` based on the type of device information is being requested for.  This works by passing the `IDeviceInformation` interface as a parameter into the API's `DevicesController`.  When the API's `DevicesController::info(Request $request)` endpoint is executed, the service provider will bind the correct abstraction based on the type of the device.  This supports dynamically switching dependencies at runtime for the API's `DeviceController`.