### PR TITLE
Introduced middleware to add "Content-Length" header to a response

### DIFF
--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -69,7 +69,9 @@ class DevicesController extends Controller
             return response()->json(['error' => 'Unauthorized'], 401);
         }
 
-        return $this->deviceInformation->info($deviceId, $action);
+        $info = $this->deviceInformation->info($deviceId, $action);
+
+        return $info;
     }
 
     private function handleControlRequest(Request $request, $action, $responseName)

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -50,6 +50,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'apiAuthenticator' => \App\Http\Middleware\ApiAuthenticator::class
+        'apiAuthenticator' => \App\Http\Middleware\ApiAuthenticator::class,
+        'addContentLengthHeader' => \App\Http\Middleware\AddContentLengthHeader::class
     ];
 }

--- a/app/Http/Middleware/AddContentLengthHeader.php
+++ b/app/Http/Middleware/AddContentLengthHeader.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class AddContentLengthHeader
+{
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        mb_internal_encoding('UTF-8');
+
+        $content = $response->getOriginalContent();
+        $decodedJson = json_encode($content);
+        $length = mb_strlen($decodedJson);
+
+        $response->header('Content-Length', $length);
+
+        return $response;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,4 +3,4 @@
 Route::resource('/devices', 'API\DevicesController');
 Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn');
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff');
-Route::post('/devices/info', 'API\DevicesController@info')->name('info');
+Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('addContentLengthHeader');

--- a/tests/unit/controller/api/DeviceControllerTest.php
+++ b/tests/unit/controller/api/DeviceControllerTest.php
@@ -131,18 +131,26 @@ class DeviceControllerTest extends DeviceControllerTestCase
     {
         $user = $this->givenSingleUserExists();
         $device = $this->createDevice(self::$faker->word(), $user);
+        $action = self::$faker->word();
+        $responseContent = self::$faker->word();
 
         $this->givenDoesUserOwnDevice($user, $device->id, true);
 
-        $this->mockDeviceInformation->shouldReceive('info')->once();
+        $this->mockDeviceInformation->shouldReceive('info')
+            ->withArgs([$device->id, $action])
+            ->andReturn($responseContent)
+            ->once();
 
         $response = $this->postJson('/api/devices/info', [
             'userId' => $user->user_id,
-            'action' => self::$faker->word(),
+            'action' => $action,
             'deviceId' => $device->id
         ], []);
 
+        $surroundingQuotesFromJsonEncode = 2;
+
         $response->assertStatus(200);
+        $response->assertHeader('Content-Length', strlen($responseContent) + $surroundingQuotesFromJsonEncode);
     }
 
     public function testInfo_GivenRandomUserAndDevice_Returns401()


### PR DESCRIPTION
Using chunked transfer encoding as the HTTP response was causing issues for the ESP8266 when hitting the `info` endpoint.  The ESP8266 was trying to read the chunk size as part of the response.  I don't need chunked transfer encoding for this, so reverting to "Content-Length" will work and is probably better for limited capability hardware like the ESP8266.