### PR TITLE
Added default implementation for IDeviceInformation

### DIFF
--- a/app/Http/Controllers/API/DeviceInformation/ErrantDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/ErrantDeviceInformation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\API\DeviceInformation;
+
+class ErrantDeviceInformation implements IDeviceInformation
+{
+    public function info($deviceId, $action)
+    {
+        return response()->json(['error' => 'Bad Request'], 400);
+    }
+}

--- a/app/Providers/DeviceInformationServiceProvider.php
+++ b/app/Providers/DeviceInformationServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\API\DeviceInformation\ErrantDeviceInformation;
+use App\Http\Controllers\API\DeviceInformation\IDeviceInformation;
+use App\Http\Controllers\API\DeviceInformation\RFDeviceInformation;
 use App\Http\Globals\DeviceTypes;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
@@ -18,6 +21,7 @@ class DeviceInformationServiceProvider extends ServiceProvider
     public function registerDeviceInformationTypes(Request $request)
     {
         if (!$request->has('deviceId')) {
+            $this->app->bind(IDeviceInformation::class, ErrantDeviceInformation::class);
             return;
         }
 
@@ -28,20 +32,19 @@ class DeviceInformationServiceProvider extends ServiceProvider
         $device = $deviceModel->find($deviceId);
 
         if ($device === null) {
+            $this->app->bind(IDeviceInformation::class, ErrantDeviceInformation::class);
             return;
         }
 
         $deviceType = $device->device_type_id;
 
-        $deviceInformationInterface = 'App\Http\Controllers\API\DeviceInformation\IDeviceInformation';
-
         if ($deviceType === DeviceTypes::RF_DEVICE) {
-            $this->app->bind($deviceInformationInterface, 'App\Http\Controllers\API\DeviceInformation\RFDeviceInformation');
+            $this->app->bind(IDeviceInformation::class, RFDeviceInformation::class);
         }
     }
 
     public function provides()
     {
-        return ['App\Http\Controllers\API\DeviceInformation\IDeviceInformation'];
+        return [IDeviceInformation::class];
     }
 }

--- a/tests/unit/controller/api/deviceInformation/ErrantDeviceInformationTest.php
+++ b/tests/unit/controller/api/deviceInformation/ErrantDeviceInformationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Controller\Api\DeviceInformation;
+
+use App\Http\Controllers\API\DeviceInformation\ErrantDeviceInformation;
+use Tests\TestCase;
+
+class ErrantDeviceInformationTest extends TestCase
+{
+    public function testInfo()
+    {
+        $errantDeviceInformation = new ErrantDeviceInformation();
+        $response = $errantDeviceInformation->info(\Mockery::any(), \Mockery::any());
+
+        $this->assertEquals($response->status(), 400);
+    }
+}


### PR DESCRIPTION
The `ErrantDeviceInformation` class will always return a 400 error.  This class is used as a default implementation of `IDeviceInformation` to be passed into the API's `DevicesController`.  The reason this is necessary is before this change, calling an endpoint (besides `info(Request $request)`) in the API's `DevicesController` would cause a 500 error because there wasn't a value for `IDeviceInformation` it was left unregistered.  This will now more gracefully give the user a 400 error.  Another option to solve this that I approached was to remove `IDeviceInformation` from the API's `DevicesController` altogether and to just call the `info(Request $request)` function directly for each implementation, but I couldn't figure out a graceful way to dynamically pick the correct instance of `IDeviceInformation` to call.