### PR TITLE
Add parameter and return type hinting when applicable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ RoboHome is a SaaS tool that also integrates with Amazon's Echo to enable contro
 
 ### Requirements :white_check_mark:
 
-1. Webserver with PHP 7.0 or greater (7.1 is preferred) with MySQL
+1. Webserver with PHP 7.1 or greater with MySQL
 2. SSL/TLS cert [available for Free with Let's Encrypt](https://www.letsencrypt.org/).  Note, we must use _slightly_ less secure ciphers than the max due to hardware limitations of the ESP8266 which will need to talk to the RoboHome-Web API over HTTPS to gather information about devices.  If set up correctly, by entering your website in [SSL Lab's SSL Server Test](https://www.ssllabs.com/ssltest/index.html), you should still get an "A" rating.  To get the appropiate ciphers for your server visit [Cipherli.st](https://cipherli.st/) and click "Yes, give me a ciphersuite that works with legacy / old software."
 2. MQTT broker for pub-sub. I personally use [CloudMQTT](https://www.cloudmqtt.com/). This service is used to send messages from a webservice to a microcontroller.
 3. An account with [Amazon](https://www.amazon.com/) to be used for account registration using OAuth.

--- a/app/Device.php
+++ b/app/Device.php
@@ -10,12 +10,12 @@ class Device extends Model
     protected $fillable = ['name', 'description', 'type'];
     protected $table = 'devices';
 
-    public function add(string $name, string $description, int $type, string $userId) : Device
+    public function add(string $name, string $description, string $userId, int $type) : Device
     {
         $this->name = $name;
         $this->description = $description;
-        $this->device_type_id = $type;
         $this->user_id = $userId;
+        $this->device_type_id = $type;
         $this->save();
 
         return $this;

--- a/app/Device.php
+++ b/app/Device.php
@@ -3,13 +3,14 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Device extends Model
 {
     protected $fillable = ['name', 'description', 'type'];
     protected $table = 'devices';
 
-    public function add($name, $description, $type, $userId)
+    public function add(string $name, string $description, int $type, string $userId) : Device
     {
         $this->name = $name;
         $this->description = $description;
@@ -20,7 +21,7 @@ class Device extends Model
         return $this;
     }
 
-    public function rfDevice()
+    public function rfDevice() : HasOne
     {
         return $this->hasOne(RFDevice::class);
     }

--- a/app/Http/Authentication/AmazonLoginAuthenticator.php
+++ b/app/Http/Authentication/AmazonLoginAuthenticator.php
@@ -17,7 +17,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         $this->userModel = $userModel;
     }
 
-    public function processLoginRequest(Request $request)
+    public function processLoginRequest(Request $request) : ?User
     {
         $accessToken = $request->query('access_token');
 
@@ -26,7 +26,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return $loggedInUser;
     }
 
-    public function processApiLoginRequest(Request $request)
+    public function processApiLoginRequest(Request $request) : ?User
     {
         $httpAuthorizationHeader = $request->header('Authorization');
 
@@ -43,7 +43,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return $loggedInUser;
     }
 
-    private function getUserForAccessToken($accessToken)
+    private function getUserForAccessToken(?string $accessToken) : ?User
     {
         if (empty($accessToken) || !$this->verifyUserTokenMatchesAmazonToken($accessToken)) {
             return null;
@@ -59,7 +59,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return $loggedInUser;
     }
 
-    private function verifyUserTokenMatchesAmazonToken($accessToken)
+    private function verifyUserTokenMatchesAmazonToken(string $accessToken) : bool
     {
         $amazonOAuthUrl = 'https://api.amazon.com/auth/o2/tokeninfo?access_token=' . urlencode($accessToken);
         $this->curlRequest->init($amazonOAuthUrl);
@@ -81,7 +81,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return true;
     }
 
-    private function exchangeAccessTokenForDecodedUserProfile($accessToken)
+    private function exchangeAccessTokenForDecodedUserProfile(string $accessToken)
     {
         $this->curlRequest->init('https://api.amazon.com/user/profile');
         $httpHeaders = ['Authorization: bearer ' . $accessToken];
@@ -94,7 +94,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return $decodedUserProfileArray;
     }
 
-    private function getLoggedInUserProfile($decodedUserProfile)
+    private function getLoggedInUserProfile($decodedUserProfile) : ?User
     {
         $userId = $decodedUserProfile->user_id;
         $loggedInUser = $this->userModel->where('user_id', $userId)->first();
@@ -102,7 +102,7 @@ class AmazonLoginAuthenticator implements ILoginAuthenticator
         return $loggedInUser;
     }
 
-    private function createNewUserIfUserDoesNotExist($decodedUserProfile)
+    private function createNewUserIfUserDoesNotExist($decodedUserProfile) : User
     {
         $user = $this->userModel->add(
             $decodedUserProfile->name,

--- a/app/Http/Authentication/ILoginAuthenticator.php
+++ b/app/Http/Authentication/ILoginAuthenticator.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Authentication;
 
+use App\User;
 use Illuminate\Http\Request;
 
 interface ILoginAuthenticator
 {
-    public function processLoginRequest(Request $request);
+    public function processLoginRequest(Request $request) : ?User;
 
-    public function processApiLoginRequest(Request $request);
+    public function processApiLoginRequest(Request $request) : ?User;
 }

--- a/app/Http/Controllers/API/DeviceInformation/ErrantDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/ErrantDeviceInformation.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\API\DeviceInformation;
 
+use Illuminate\Http\JsonResponse;
+
 class ErrantDeviceInformation implements IDeviceInformation
 {
-    public function info($deviceId, $action)
+    public function info(int $deviceId, string $action) : JsonResponse
     {
         return response()->json(['error' => 'Bad Request'], 400);
     }

--- a/app/Http/Controllers/API/DeviceInformation/IDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/IDeviceInformation.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers\API\DeviceInformation;
 
+use Illuminate\Http\JsonResponse;
+
 interface IDeviceInformation
 {
-    public function info($deviceId, $action);
+    public function info(int $deviceId, string $action) : JsonResponse;
 }

--- a/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\DeviceInformation;
 
 use App\RFDevice;
+use Illuminate\Http\JsonResponse;
 
 class RFDeviceInformation implements IDeviceInformation
 {
@@ -13,7 +14,7 @@ class RFDeviceInformation implements IDeviceInformation
         $this->rfDeviceModel = $rfDeviceModel;
     }
 
-    public function info($deviceId, $action)
+    public function info(int $deviceId, string $action) : JsonResponse
     {
         $rfDevice = $this->rfDeviceModel->where('device_id', $deviceId)->first();
 

--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Common\Controller;
 use App\Http\Globals\DeviceActions;
 use App\Http\MQTT\MessagePublisher;
 use App\User;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class DevicesController extends Controller
@@ -27,7 +28,7 @@ class DevicesController extends Controller
         $this->deviceInformation = $deviceInformation;
     }
 
-    public function index(Request $request)
+    public function index(Request $request) : JsonResponse
     {
         $userId = $request->get('currentUserId');
 
@@ -43,21 +44,21 @@ class DevicesController extends Controller
         return response()->json($response);
     }
 
-    public function turnOn(Request $request)
+    public function turnOn(Request $request) : JsonResponse
     {
         $response = $this->handleControlRequest($request, DeviceActions::TURN_ON, 'TurnOnConfirmation');
 
         return $response;
     }
 
-    public function turnOff(Request $request)
+    public function turnOff(Request $request) : JsonResponse
     {
         $response = $this->handleControlRequest($request, DeviceActions::TURN_OFF, 'TurnOffConfirmation');
 
         return $response;
     }
 
-    public function info(Request $request)
+    public function info(Request $request) : JsonResponse
     {
         $userId = $request->get('userId');
         $deviceId = $request->get('deviceId');
@@ -72,7 +73,7 @@ class DevicesController extends Controller
         return $this->deviceInformation->info($deviceId, $action);
     }
 
-    private function handleControlRequest(Request $request, $action, $responseName)
+    private function handleControlRequest(Request $request, string $action, string $responseName) : JsonResponse
     {
         $userId = $request->get('currentUserId');
         $deviceId = $request->input('id');
@@ -120,7 +121,7 @@ class DevicesController extends Controller
         return $appliances;
     }
 
-    private function createHeader(Request $request, $responseName, $namespace)
+    private function createHeader(Request $request, string $responseName, string $namespace)
     {
         $messageId = $request->header('Message-Id');
 
@@ -134,14 +135,14 @@ class DevicesController extends Controller
         return $header;
     }
 
-    private function currentUser($userId)
+    private function currentUser(string $userId) : User
     {
         $currentUser = $this->userModel->where('user_id', $userId)->first();
 
         return $currentUser;
     }
 
-    private function doesUserOwnDevice($userId, $deviceId)
+    private function doesUserOwnDevice(string $userId, int $deviceId) : bool
     {
         $currentUser = $this->currentUser($userId);
 

--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -86,7 +86,7 @@ class DevicesController extends Controller
 
         $urlValidAction = strtolower($action);
 
-        $this->messagePublisher->publish($userId, $deviceId, $urlValidAction);
+        $this->messagePublisher->publish($userId, $urlValidAction, $deviceId);
 
         $response = [
             'header' => $this->createHeader($request, $responseName, 'Alexa.ConnectedHome.Control'),

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -10,7 +10,9 @@ use App\Http\MQTT\MessagePublisher;
 use App\RFDevice;
 use App\User;
 use DB;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class DevicesController extends Controller
 {
@@ -29,7 +31,7 @@ class DevicesController extends Controller
         $this->messagePublisher = $messagePublisher;
     }
 
-    public function devices()
+    public function devices() : View
     {
         $currentUser = $this->currentUser();
 
@@ -39,7 +41,7 @@ class DevicesController extends Controller
         ]);
     }
 
-    public function add(Request $request)
+    public function add(Request $request) : RedirectResponse
     {
         $name = $request->input('name');
         $description = $request->input('description');
@@ -57,7 +59,7 @@ class DevicesController extends Controller
         return redirect()->route('devices');
     }
 
-    public function delete(Request $request, $id)
+    public function delete(Request $request, int $id) : RedirectResponse
     {
         $doesUserOwnDevice = $this->currentUser()->doesUserOwnDevice($id);
 
@@ -76,7 +78,7 @@ class DevicesController extends Controller
         return redirect()->route('devices');
     }
 
-    public function handleControlRequest(Request $request, $action, $deviceId)
+    public function handleControlRequest(Request $request, string $action, int $deviceId) : RedirectResponse
     {
         $currentUser = $this->currentUser();
         $doesUserOwnDevice = $currentUser->doesUserOwnDevice($deviceId);
@@ -92,7 +94,7 @@ class DevicesController extends Controller
         return redirect()->route('devices');
     }
 
-    private function currentUser()
+    private function currentUser() : User
     {
         $userId = session(env('SESSION_USER_ID'));
         $currentUser = $this->userModel->where('user_id', $userId)->first();

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -89,7 +89,7 @@ class DevicesController extends Controller
             return redirect()->route('devices');
         }
 
-        $this->messagePublisher->publish($currentUser->user_id, $deviceId, $action);
+        $this->messagePublisher->publish($currentUser->user_id, $action, $deviceId);
 
         return redirect()->route('devices');
     }

--- a/app/Http/Controllers/Web/LoginController.php
+++ b/app/Http/Controllers/Web/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Web;
 
 use App\Http\Authentication\ILoginAuthenticator;
 use App\Http\Controllers\Common\Controller;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class LoginController extends Controller
@@ -24,7 +25,7 @@ class LoginController extends Controller
         return view('index');
     }
 
-    public function login(Request $request)
+    public function login(Request $request) : RedirectResponse
     {
         $loggedInUser = $this->loginAuthenticator->processLoginRequest($request);
 
@@ -37,7 +38,7 @@ class LoginController extends Controller
         return redirect()->route('devices');
     }
 
-    public function logout(Request $request)
+    public function logout(Request $request) : RedirectResponse
     {
         $request->session()->flush();
 

--- a/app/Http/MQTT/MessagePublisher.php
+++ b/app/Http/MQTT/MessagePublisher.php
@@ -13,7 +13,7 @@ class MessagePublisher
         $this->client = $client;
     }
 
-    public function publish(string $userId, int $deviceId, string $action) : bool
+    public function publish(string $userId, string $action, int $deviceId) : bool
     {
         if (!$this->client->connect()) {
             return false;

--- a/app/Http/MQTT/MessagePublisher.php
+++ b/app/Http/MQTT/MessagePublisher.php
@@ -13,7 +13,7 @@ class MessagePublisher
         $this->client = $client;
     }
 
-    public function publish($userId, $deviceId, $action)
+    public function publish(string $userId, int $deviceId, string $action) : bool
     {
         if (!$this->client->connect()) {
             return false;

--- a/app/Http/Middleware/ApiAuthenticator.php
+++ b/app/Http/Middleware/ApiAuthenticator.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use App\Http\Authentication\ILoginAuthenticator;
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class ApiAuthenticator
 {
@@ -15,7 +16,7 @@ class ApiAuthenticator
         $this->loginAuthenticator = $loginAuthenticator;
     }
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next) : Response
     {
         $user = $this->loginAuthenticator->processApiLoginRequest($request);
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -3,10 +3,12 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class RedirectIfAuthenticated
 {
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next) : Response
     {
         if ($request->session()->has(env('SESSION_USER_ID'))) {
             return $next($request);

--- a/app/Http/Wrappers/CurlRequest.php
+++ b/app/Http/Wrappers/CurlRequest.php
@@ -6,17 +6,17 @@ class CurlRequest implements ICurlRequest
 {
     private $handle = null;
 
-    public function init($url)
+    public function init(string $url)
     {
         $this->handle = curl_init($url);
     }
 
-    public function setOption($name, $value)
+    public function setOption(string $name, $value)
     {
         curl_setopt($this->handle, $name, $value);
     }
 
-    public function execute()
+    public function execute() : string
     {
         return curl_exec($this->handle);
     }

--- a/app/Http/Wrappers/ICurlRequest.php
+++ b/app/Http/Wrappers/ICurlRequest.php
@@ -4,11 +4,11 @@ namespace App\Http\Wrappers;
 
 interface ICurlRequest
 {
-    public function init($url);
+    public function init(string $url);
 
-    public function setOption($name, $value);
+    public function setOption(string $name, $value);
 
-    public function execute();
+    public function execute() : string;
 
     public function close();
 }

--- a/app/RFDevice.php
+++ b/app/RFDevice.php
@@ -9,7 +9,7 @@ class RFDevice extends Model
     protected $fillable = ['on_code', 'off_code', 'pulse_length', 'device_id'];
     protected $table = 'rf_devices';
 
-    public function add($onCode, $offCode, $pulseLength, $deviceId)
+    public function add(int $onCode, int $offCode, int $pulseLength, int $deviceId) : RFDevice
     {
         $this->on_code = $onCode;
         $this->off_code = $offCode;

--- a/app/User.php
+++ b/app/User.php
@@ -3,13 +3,14 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Model
 {
     protected $fillable = ['name', 'email', 'user_id'];
     protected $table = 'users';
 
-    public function add($name, $email, $userId)
+    public function add(string $name, string $email, string $userId) : User
     {
         $this->name = $name;
         $this->email = $email;
@@ -19,12 +20,12 @@ class User extends Model
         return $this;
     }
 
-    public function devices()
+    public function devices() : HasMany
     {
         return $this->hasMany(Device::class);
     }
 
-    public function doesUserOwnDevice($deviceId)
+    public function doesUserOwnDevice($deviceId) : bool
     {
         return $this->devices->contains($deviceId);
     }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0+",
     "type": "project",
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "laravel/framework": "5.4.*",
         "mcfish/libmqtt": "^1.0.0"
     },
@@ -47,9 +47,6 @@
         ]
     },
     "config": {
-        "platform": {
-            "php": "7.0"
-        },
         "preferred-install": "dist",
         "sort-packages": true
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bbc351173c75f76be76d6aad1cbfc8d",
+    "content-hash": "c9fded7336d7a2bec1af5cc91274dea5",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1616,32 +1616,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1666,7 +1666,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -3653,10 +3653,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.0"
+        "php": ">=7.1.0"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.0"
-    }
+    "platform-dev": []
 }

--- a/tests/unit/authentication/AmazonLoginAuthenticatorTest.php
+++ b/tests/unit/authentication/AmazonLoginAuthenticatorTest.php
@@ -7,6 +7,7 @@ use App\Http\Wrappers\ICurlRequest;
 use App\User;
 use Illuminate\Http\Request;
 use Mockery;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 class AmazonLoginAuthenticatorTest extends TestCase
@@ -117,7 +118,7 @@ class AmazonLoginAuthenticatorTest extends TestCase
         $this->assertNull($result);
     }
 
-    private function givenNewUserToBeCreated()
+    private function givenNewUserToBeCreated() : User
     {
         $user = $this->createUser();
 
@@ -135,7 +136,7 @@ class AmazonLoginAuthenticatorTest extends TestCase
         return $user;
     }
 
-    private function createUser()
+    private function createUser() : User
     {
         $user = new User();
 
@@ -147,17 +148,17 @@ class AmazonLoginAuthenticatorTest extends TestCase
         return $user;
     }
 
-    private function callProcessLoginRequest()
+    private function callProcessLoginRequest() : ?User
     {
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('query')->with('access_token')->once()->andReturn(self::$faker->uuid());
 
-        $result = $this->amazonLoginAuthenticator->processLoginRequest($mockRequest);
+        $user = $this->amazonLoginAuthenticator->processLoginRequest($mockRequest);
 
-        return $result;
+        return $user;
     }
 
-    private function givenValidAuthorizationHeader()
+    private function givenValidAuthorizationHeader() : MockInterface
     {
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('header')->with('Authorization')->once()->andReturn('Bearer ' . self::$faker->uuid());
@@ -165,7 +166,7 @@ class AmazonLoginAuthenticatorTest extends TestCase
         return $mockRequest;
     }
 
-    private function givenValidCurlRequests($token, $timesInitCalled, $timesSetOptionCalled, $timesSecondExecuteIsCalled, $timesClosedIsCalled)
+    private function givenValidCurlRequests(string $token, int $timesInitCalled, int $timesSetOptionCalled, int $timesSecondExecuteIsCalled, int $timesClosedIsCalled)
     {
         $userId = self::$faker->uuid;
 
@@ -194,7 +195,7 @@ class AmazonLoginAuthenticatorTest extends TestCase
             ->shouldReceive('close')->times($timesClosedIsCalled);
     }
 
-    private function givenBadAccessTokenCurlRequests($curlReturnValue, $timesInitCalled, $timesSetOptionCalled, $timesClosedIsCalled)
+    private function givenBadAccessTokenCurlRequests(string $curlReturnValue, int $timesInitCalled, int $timesSetOptionCalled, int $timesClosedIsCalled)
     {
         $this->mockCurlRequest
             ->shouldReceive('init')->withAnyArgs()->times($timesInitCalled)

--- a/tests/unit/controller/api/deviceInformation/ErrantDeviceInformationTest.php
+++ b/tests/unit/controller/api/deviceInformation/ErrantDeviceInformationTest.php
@@ -7,10 +7,10 @@ use Tests\TestCase;
 
 class ErrantDeviceInformationTest extends TestCase
 {
-    public function testInfo()
+    public function testInfo_GivenRandomValues_Returns400()
     {
         $errantDeviceInformation = new ErrantDeviceInformation();
-        $response = $errantDeviceInformation->info(\Mockery::any(), \Mockery::any());
+        $response = $errantDeviceInformation->info(self::$faker->randomDigit(), self::$faker->word());
 
         $this->assertEquals($response->status(), 400);
     }

--- a/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
+++ b/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controller\Api\DeviceInformation;
 use App\Http\Controllers\API\DeviceInformation\RFDeviceInformation;
 use App\Http\Globals\DeviceActions;
 use App\RFDevice;
+use Illuminate\Http\JsonResponse;
 use Mockery;
 use Tests\TestCase;
 
@@ -55,7 +56,7 @@ class RFDeviceInformationTest extends TestCase
         $this->assertEquals($result['error'], "Device does not support action '$action'");
     }
 
-    private function callInfo($action)
+    private function callInfo(string $action) : JsonResponse
     {
         $rfDevice = $this->createRFDevice($this->onCode, $this->offCode);
         $rfDeviceInformation = $this->givenRFDeviceInformation($rfDevice);
@@ -65,7 +66,7 @@ class RFDeviceInformationTest extends TestCase
         return $response;
     }
 
-    private function givenRFDeviceInformation($rfDevice)
+    private function givenRFDeviceInformation(RFDevice $rfDevice) : RFDeviceInformation
     {
         $mockRFDeviceTable = Mockery::mock(RFDevice::class);
         $mockRFDeviceTable
@@ -77,7 +78,7 @@ class RFDeviceInformationTest extends TestCase
         return $rfDeviceInformation;
     }
 
-    private function createRFDevice($onCode, $offCode)
+    private function createRFDevice(int $onCode, int $offCode) : RFDevice
     {
         $rfDevice = new RFDevice();
 

--- a/tests/unit/controller/common/DeviceControllerTestCase.php
+++ b/tests/unit/controller/common/DeviceControllerTestCase.php
@@ -6,10 +6,11 @@ use App\Device;
 use App\Http\MQTT\MessagePublisher;
 use App\User;
 use Mockery;
+use Mockery\MockInterface;
 
 class DeviceControllerTestCase extends ControllerTestCase
 {
-    protected function givenSingleUserExists()
+    protected function givenSingleUserExists() : User
     {
         $user = $this->createUser(self::$faker->uuid());
 
@@ -23,7 +24,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         return $user;
     }
 
-    protected function givenSingleUserExistsWithDevices($device1Name, $device2Name, $device3Name)
+    protected function givenSingleUserExistsWithDevices(string $device1Name, string $device2Name, string $device3Name) : User
     {
         $userId = self::$faker->uuid();
 
@@ -47,7 +48,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         return $user;
     }
 
-    protected function givenDeviceIsRegisteredToUser($device, $userId)
+    protected function givenDeviceIsRegisteredToUser(Device $device, string $userId)
     {
         $collection = new Device();
 
@@ -59,7 +60,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         $this->mockUserTable($mockUserRecord, $userId);
     }
 
-    protected function givenSingleUserExistsWithSingleDevice()
+    protected function givenSingleUserExistsWithSingleDevice() : Device
     {
         $userId = self::$faker->uuid();
 
@@ -77,7 +78,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         return $device;
     }
 
-    protected function createUser($userId)
+    protected function createUser(string $userId) : User
     {
         $user = new User();
 
@@ -89,7 +90,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         return $user;
     }
 
-    protected function mockUserTable($mockUserRecord, $userId)
+    protected function mockUserTable(MockInterface $mockUserRecord, string $userId)
     {
         $mockUserTable = Mockery::mock(User::class);
         $mockUserTable
@@ -99,7 +100,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         $this->app->instance(User::class, $mockUserTable);
     }
 
-    protected function mockMessagePublisher($timesPublishIsCalled = 1)
+    protected function mockMessagePublisher(int $timesPublishIsCalled = 1)
     {
         $mockMessagePublisher = Mockery::mock(MessagePublisher::class);
         $mockMessagePublisher
@@ -110,7 +111,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         $this->app->instance(MessagePublisher::class, $mockMessagePublisher);
     }
 
-    protected function createDevice($deviceName, $userId)
+    protected function createDevice(string $deviceName, string $userId) : Device
     {
         Device::unguard();
 
@@ -126,7 +127,7 @@ class DeviceControllerTestCase extends ControllerTestCase
         return $device;
     }
 
-    protected function givenDoesUserOwnDevice($user, $deviceId, $doesUserOwnDevice)
+    protected function givenDoesUserOwnDevice(User $user, int $deviceId, bool $doesUserOwnDevice) : MockInterface
     {
         $mockUserRecord = Mockery::mock(User::class);
         $mockUserRecord->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);

--- a/tests/unit/controller/web/DeviceControllerTest.php
+++ b/tests/unit/controller/web/DeviceControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controller\Web;
 use App\Device;
 use App\RFDevice;
 use App\User;
+use Illuminate\Foundation\Testing\TestResponse;
 use Mockery;
 use Tests\Unit\Controller\Common\DeviceControllerTestCase;
 
@@ -172,7 +173,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
         $response->assertSessionHas('alert-danger');
     }
 
-    private function callControl($userId, $action, $deviceId)
+    private function callControl(string $userId, string $action, int $deviceId) : TestResponse
     {
         $response = $this->withSession([env('SESSION_USER_ID') => $userId])
             ->post("/devices/$action/$deviceId");
@@ -180,7 +181,7 @@ class DeviceControllerTest extends DeviceControllerTestCase
         return $response;
     }
 
-    private function givenUserOwnsDeviceForDeletion($user)
+    private function givenUserOwnsDeviceForDeletion(User $user) : int
     {
         $deviceId = self::$faker->randomDigit();
 
@@ -197,10 +198,12 @@ class DeviceControllerTest extends DeviceControllerTestCase
         return $deviceId;
     }
 
-    private function addDeviceForUser($userId, $deviceName)
+    private function addDeviceForUser(string $userId, string $deviceName) : TestResponse
     {
+        $device = $this->createDevice($deviceName, $userId);
+
         $mockDeviceModel = Mockery::mock(Device::class);
-        $mockDeviceModel->shouldReceive('add')->withAnyArgs()->once()->andReturn(new Device());
+        $mockDeviceModel->shouldReceive('add')->withAnyArgs()->once()->andReturn($device);
         $this->app->instance(Device::class, $mockDeviceModel);
 
         $mockRFDeviceModel = Mockery::mock(RFDevice::class);

--- a/tests/unit/model/DeviceTest.php
+++ b/tests/unit/model/DeviceTest.php
@@ -12,10 +12,10 @@ class DeviceTest extends ModelTestCase
         $device = new Device();
         $name = self::$faker->word();
         $description = self::$faker->sentence();
-        $type = self::$faker->randomDigit();
         $userId = self::$faker->randomDigit();
+        $type = self::$faker->randomDigit();
 
-        $device = $device->add($name, $description, $type, $userId);
+        $device = $device->add($name, $description, $userId, $type);
 
         $this->assertCount(1, Device::all());
         $this->assertEquals($name, $device->name);

--- a/tests/unit/model/DeviceTest.php
+++ b/tests/unit/model/DeviceTest.php
@@ -48,7 +48,7 @@ class DeviceTest extends ModelTestCase
         $this->assertEquals(0, RFDevice::count());
     }
 
-    private function addDeviceToDatabase()
+    private function addDeviceToDatabase() : Device
     {
         $device = new Device();
         $name = self::$faker->word();
@@ -61,7 +61,7 @@ class DeviceTest extends ModelTestCase
         return $addedDevice;
     }
 
-    private function addRFDeviceToDatabase(Device $device)
+    private function addRFDeviceToDatabase(Device $device) : RFDevice
     {
         $rfDevice = new RFDevice();
         $onCode = self::$faker->randomNumber();

--- a/tests/unit/model/UserTest.php
+++ b/tests/unit/model/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends ModelTestCase
         $user = $this->createUser();
 
         $device = new Device();
-        $device = $device->add(self::$faker->word(), self::$faker->sentence(), self::$faker->randomDigit(), $user->id);
+        $device = $device->add(self::$faker->word(), self::$faker->sentence(), $user->id, self::$faker->randomDigit());
 
         $doesUserOwnDevice = $user->doesUserOwnDevice($device->id);
 
@@ -80,6 +80,6 @@ class UserTest extends ModelTestCase
     private function createDevice(string $userId)
     {
         $device = new Device();
-        $device->add(self::$faker->word(), self::$faker->sentence(), self::$faker->randomDigit(), $userId);
+        $device->add(self::$faker->word(), self::$faker->sentence(), $userId, self::$faker->randomDigit());
     }
 }

--- a/tests/unit/model/UserTest.php
+++ b/tests/unit/model/UserTest.php
@@ -65,7 +65,7 @@ class UserTest extends ModelTestCase
         $this->assertTrue($doesUserOwnDevice);
     }
 
-    private function createUser()
+    private function createUser() : User
     {
         $user = new User();
         $name = self::$faker->name();
@@ -77,7 +77,7 @@ class UserTest extends ModelTestCase
         return $user;
     }
 
-    private function createDevice($userId)
+    private function createDevice(string $userId)
     {
         $device = new Device();
         $device->add(self::$faker->word(), self::$faker->sentence(), self::$faker->randomDigit(), $userId);

--- a/tests/unit/mqtt/MessagePublisherTest.php
+++ b/tests/unit/mqtt/MessagePublisherTest.php
@@ -33,7 +33,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->userId, $this->deviceId, $this->action);
+        $result = $messagePublisher->publish($this->userId, $this->action, $this->deviceId);
 
         $this->assertTrue($result);
     }
@@ -47,7 +47,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->userId, $this->deviceId, $this->action);
+        $result = $messagePublisher->publish($this->userId, $this->action, $this->deviceId);
 
         $this->assertFalse($result);
     }


### PR DESCRIPTION
-Unless the type is "mixed," it should now be explicitly typed
-This will require PHP 7.1
-Able to remove the `platform` config from `composer.json` since all the dependencies by default work with PHP >=7.1