### PR TITLE
Added phpmdruleset.xml file for use with Code Climate

### DIFF
--- a/phpmdruleset.xml
+++ b/phpmdruleset.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="PHPMD ruleset for RoboHome-Web" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>PHPMD ruleset for RoboHome-Web</description>
+    <rule ref="rulesets/codesize.xml">
+        <exclude name="ExcessiveMethodLength" />
+    </rule>
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable" />
+        <exclude name="LongVariable" />
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="25" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="exceptions" value="db,f3,id" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable">
+        <properties>
+            <property name="maximum" value="35" />
+        </properties>
+    </rule>
+</ruleset>
+


### PR DESCRIPTION
Re-adding the custom PHPMD ruleset file referenced in `.codeclimate.yml`.  It got lost during the port to Laravel.  No idea why it was working up until recently (maybe Code Climate has it cached).