### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Homestead.json
 Homestead.yaml
 .env
+.DS_Store


### PR DESCRIPTION
This is a file used in macOS to describe properties of a folder.