### PR TITLE
Type hint method parameter

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -42,7 +42,7 @@ class Handler extends ExceptionHandler
      * @param  \Exception  $exception
      * @return \Illuminate\Http\Response
      */
-    public function render($request, Exception $exception)
+    public function render(\Illuminate\Http\Request $request, Exception $exception)
     {
         return parent::render($request, $exception);
     }


### PR DESCRIPTION
Full class name can be added at the top via `use` opted for this option as it's the only occurance