### PR TITLE
Remove exception that was used before switching to Laravel

### DIFF
--- a/phpmdruleset.xml
+++ b/phpmdruleset.xml
@@ -18,7 +18,7 @@
     </rule>
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <property name="exceptions" value="db,f3,id" />
+            <property name="exceptions" value="db,id" />
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/LongVariable">


### PR DESCRIPTION
When this project still used F3 instead of Laravel, there was an exception made for the variable `f3` that is no longer needed.