### PR TITLE
Fixed guest middleware name

### DIFF
--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -23,7 +23,7 @@ class DevicesController extends Controller
 
     public function __construct(Device $deviceModel, RFDevice $rfDeviceModel, User $userModel, MessagePublisher $messagePublisher)
     {
-        $this->middleware('guest');
+        $this->middleware('authenticated');
 
         $this->deviceModel = $deviceModel;
         $this->rfDeviceModel = $rfDeviceModel;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -48,7 +48,7 @@ class Kernel extends HttpKernel
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'authenticated' => \App\Http\Middleware\RedirectIfGuest::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'apiAuthenticator' => \App\Http\Middleware\ApiAuthenticator::class
     ];

--- a/app/Http/Middleware/RedirectIfGuest.php
+++ b/app/Http/Middleware/RedirectIfGuest.php
@@ -6,7 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RedirectIfAuthenticated
+class RedirectIfGuest
 {
     public function handle(Request $request, Closure $next): Response
     {


### PR DESCRIPTION
Renamed the guest middleware from `RedirectIfAuthenticated` to `RedirectIfGuest` and controller middleware name accordingly.