### PR TITLE
OAuth fixes for 3rd party account linking

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -56,6 +56,8 @@ class Kernel extends HttpKernel
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'scope' => \Laravel\Passport\Http\Middleware\CheckForAnyScope::class,
+        'scopes' => \Laravel\Passport\Http\Middleware\CheckScopes::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -26,6 +26,10 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
+        Passport::tokensCan([
+            'control' => 'Access user profile and control devices'
+        ]);
+
         Passport::routes();
     }
 }

--- a/resources/views/devices.blade.php
+++ b/resources/views/devices.blade.php
@@ -27,6 +27,9 @@
 
             function controlDevice(action, id) {
                 $.ajax({
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                    },
                     type: "POST",
                     url: "/devices/" + action + "/" + id
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,11 +2,11 @@
 
 use Illuminate\Http\Request;
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
+Route::get('/user', function (Request $request) {
     return $request->user();
-});
+})->middleware('auth:api', 'scope:control');
 
 Route::resource('/devices', 'API\DevicesController');
 Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn');
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff');
-Route::post('/devices/info', 'API\DevicesController@info')->name('info');
+Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:control');

--- a/tests/unit/controller/api/DevicesControllerTest.php
+++ b/tests/unit/controller/api/DevicesControllerTest.php
@@ -25,7 +25,7 @@ class DevicesControllerTest extends DevicesControllerTestCase
 
         $this->app->instance(IDeviceInformation::class, $this->mockDeviceInformation);
 
-        $this->messageId = self::$faker->uuid;
+        $this->messageId = self::$faker->uuid();
     }
 
     public function testIndex_GivenUserExistsWithNoDevices_ReturnsJsonResponse(): void
@@ -270,7 +270,10 @@ class DevicesControllerTest extends DevicesControllerTestCase
     private function mockUserOwnsDevice(int $deviceId, bool $doesUserOwnDevice): User
     {
         $mockUser = $this->createMockUser();
-        $mockUser->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);
+        $mockUser
+            ->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice)
+            ->shouldReceive('token')->andReturn(self::$faker->uuid())
+            ->shouldReceive('tokenCan')->andReturn(self::$faker->word());
 
         return $mockUser;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->

## Description
When initially porting this project to Laravel Passport, it was hard to test locally since I didn't have HTTPS set up locally.  When merged, I found a few flaws while trying to link my Amazon Skill to my API that this hopefully fixes.  There were two problems:

1. The CSRF token wasn't being passed when requesting to perform an action.  This fixes a security vulnerability that existed in this program previously.
2. There were no OAuth scopes defined which Amazon's account linking required.  Therefore I created a scope called "control" which is currently serving as a universal scope that has access to anything the API does (which isn't much).

## Motivation and Context
To get account linking working for the RoboHome Amazon skill so it can communicate with the RoboHome API.

## How Has This Been Tested?
The CSRF token passing was tested locally to make sure it was being sent to the AJAX request.  I tested using Insomnia to make sure adding a scope will return tokens.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.
