### PR TITLE
Fix for API's info method

### DIFF
--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -5,7 +5,9 @@ namespace App\Providers;
 use App\Repositories\DeviceRepository;
 use App\Repositories\IDeviceRepository;
 use App\Repositories\IRFDeviceRepository;
+use App\Repositories\IUserRepository;
 use App\Repositories\RFDeviceRepository;
+use App\Repositories\UserRepository;
 use Illuminate\Support\ServiceProvider;
 
 class RepositoryServiceProvider extends ServiceProvider
@@ -14,5 +16,6 @@ class RepositoryServiceProvider extends ServiceProvider
     {
         $this->app->bind(IDeviceRepository::class, DeviceRepository::class);
         $this->app->bind(IRFDeviceRepository::class, RFDeviceRepository::class);
+        $this->app->bind(IUserRepository::class, UserRepository::class);
     }
 }

--- a/app/Repositories/IUserRepository.php
+++ b/app/Repositories/IUserRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Repositories;
+
+use App\User;
+
+interface IUserRepository
+{
+    public function get(int $id): User;
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Repositories;
+
+use App\User;
+
+class UserRepository implements IUserRepository
+{
+    public function get(int $id): User
+    {
+        return User::findOrFail($id);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -2,10 +2,10 @@
 
 namespace App;
 
-use Laravel\Passport\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Passport\HasApiTokens;
 
 class User extends Authenticatable
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,4 +9,4 @@ Route::get('/user', function (Request $request) {
 Route::resource('/devices', 'API\DevicesController');
 Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn');
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff');
-Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:control');
+Route::post('/devices/info', 'API\DevicesController@info')->name('info');

--- a/tests/unit/Repositories/DeviceRepositoryTest.php
+++ b/tests/unit/Repositories/DeviceRepositoryTest.php
@@ -6,7 +6,6 @@ use App\Device;
 use App\Repositories\IDeviceRepository;
 use App\Repositories\IRFDeviceRepository;
 use App\RFDevice;
-use App\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Mockery;
 
@@ -123,11 +122,6 @@ class DeviceRepositoryTest extends RepositoryTestCaseWithRealDatabase
         $name = $this->deviceRepository->name($device->id);
 
         $this->assertEquals($device->name, $name);
-    }
-
-    private function createUser(): User
-    {
-        return factory(User::class)->create();
     }
 
     private function createDevice(): Device

--- a/tests/unit/Repositories/RepositoryTestCaseWithRealDatabase.php
+++ b/tests/unit/Repositories/RepositoryTestCaseWithRealDatabase.php
@@ -3,10 +3,16 @@
 namespace Tests\Unit\Repositories;
 
 use App\Http\Globals\DeviceTypes;
+use App\User;
 use Tests\Unit\Model\TestCaseWithRealDatabase;
 
 class RepositoryTestCaseWithRealDatabase extends TestCaseWithRealDatabase
 {
+    protected function createUser(): User
+    {
+        return factory(User::class)->create();
+    }
+
     protected function createDeviceProperties(): array
     {
         $properties = [

--- a/tests/unit/Repositories/UserRepositoryTest.php
+++ b/tests/unit/Repositories/UserRepositoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Repositories;
+
+use App\Repositories\IUserRepository;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class UserRepositoryTest extends RepositoryTestCaseWithRealDatabase
+{
+    private $userRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userRepository = $this->app->make(IUserRepository::class);
+    }
+
+    public function testGet_GivenUserDoesNotExist_ThrowsModelNotFoundException(): void
+    {
+        $nonexistentUserId = self::$faker->randomNumber();
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $this->userRepository->get($nonexistentUserId);
+    }
+
+    public function testGet_GivenUserExists_ReturnsUser(): void
+    {
+        $user = $this->createUser();
+
+        $retrievedUser = $this->userRepository->get($user->id);
+
+        $this->assertTrue($retrievedUser->is($user));
+    }
+}

--- a/tests/unit/controller/api/DevicesControllerTest.php
+++ b/tests/unit/controller/api/DevicesControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controller\Api;
 use App\Device;
 use App\Http\Controllers\API\DeviceInformation\IDeviceInformation;
 use App\Http\Globals\DeviceActions;
+use App\Repositories\UserRepository;
 use App\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\TestResponse;
@@ -125,6 +126,9 @@ class DevicesControllerTest extends DevicesControllerTestCase
     {
         $device = $this->createDevices()[0];
         $mockUser = $this->mockUserOwnsDevice($device->id, true);
+        $mockUserRepository = $this->givenGetCalledOnUserRepository($mockUser);
+
+        $this->app->instance(UserRepository::class, $mockUserRepository);
 
         $this->mockDeviceInformation->shouldReceive('info')->once()->andReturn(new JsonResponse());
 
@@ -137,6 +141,9 @@ class DevicesControllerTest extends DevicesControllerTestCase
     {
         $deviceId = self::$faker->randomDigit();
         $mockUser = $this->mockUserOwnsDevice($deviceId, false);
+        $mockUserRepository = $this->givenGetCalledOnUserRepository($mockUser);
+
+        $this->app->instance(UserRepository::class, $mockUserRepository);
 
         $response = $this->callInfo($mockUser, $deviceId);
 
@@ -276,5 +283,13 @@ class DevicesControllerTest extends DevicesControllerTestCase
             ->shouldReceive('tokenCan')->andReturn(self::$faker->word());
 
         return $mockUser;
+    }
+
+    private function givenGetCalledOnUserRepository(User $user): UserRepository
+    {
+        $mockUserRepository = Mockery::mock(UserRepository::class);
+        $mockUserRepository->shouldReceive('get')->once()->andReturn($user);
+
+        return $mockUserRepository;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->

## Description
There was an oversite where I was trying to use the currently authenticated user to retrieve info about a device.  This is problematic because the `info` method is called by the microcontroller which doesn't have the ability to authenticate users.  I reverted back to the old way where the desired user ID is passed as a query string parameter.  I had to create a `UserRepository` to make this work correctly.

## Motivation and Context
Fix the `info` method in the API so that microcontrollers with minimal processing power can `POST` to the method to get device information without having the login. 

## How Has This Been Tested?
I used Insomnia to hit the `info` method to make sure I got the correct results back for each user ID, device ID, and action.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.