### PR TITLE
Fix for Coveralls reporting in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml --configuration phpunit.xml
 
 after_success:
-  - travis_retry php vendor/bin/coveralls -v
+  - travis_retry php vendor/bin/php-coveralls -v
 
 notifications:
   slack:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->
<!--- Do not delete any section from here, if it doesn't apply, just leave it as is -->

## Description
Coveralls renamed their executable, this fix should enable reporting again.

## Motivation and Context
Coveralls is important for monitoring test coverage of builds.  This will restore that functionality.  This error could be found in the Travis CI logs on builds after updating to satooshi/php-coveralls 2.0 in pull request #128.

```
[0K$ travis_retry php vendor/bin/coveralls -v
Could not open input file: vendor/bin/coveralls

[31;1mThe command "php vendor/bin/coveralls -v" failed. Retrying, 2 of 3.[0m

Could not open input file: vendor/bin/coveralls

[31;1mThe command "php vendor/bin/coveralls -v" failed. Retrying, 3 of 3.[0m

Could not open input file: vendor/bin/coveralls

[31;1mThe command "php vendor/bin/coveralls -v" failed 3 times.[0m
```

## How Has This Been Tested?
The opening of this pull request will re-enable Coveralls reporting.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.