### PR TITLE
Publish RF device pulse length

### DIFF
--- a/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
+++ b/app/Http/Controllers/API/DeviceInformation/RFDeviceInformation.php
@@ -24,11 +24,13 @@ class RFDeviceInformation implements IDeviceInformation
 
         if ($action === 'turnon') {
             $response = [
-                'code' => $rfDevice->on_code
+                'code' => $rfDevice->on_code,
+                'pulse_length' => $rfDevice->pulse_length
             ];
         } elseif ($action === 'turnoff') {
             $response = [
-                'code' => $rfDevice->off_code
+                'code' => $rfDevice->off_code,
+                'pulse_length' => $rfDevice->pulse_length
             ];
         }
 

--- a/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
+++ b/tests/unit/controller/api/deviceInformation/RFDeviceInformationTest.php
@@ -14,6 +14,7 @@ class RFDeviceInformationTest extends TestCase
 {
     private $onCode;
     private $offCode;
+    private $pulseLength;
 
     public function setUp(): void
     {
@@ -21,6 +22,7 @@ class RFDeviceInformationTest extends TestCase
 
         $this->onCode = self::$faker->randomDigit();
         $this->offCode = self::$faker->randomDigit();
+        $this->pulseLength = self::$faker->randomDigit();
     }
 
     public function testInfo_GivenTurnOnAction_ReturnsJsonResponseWithCorrectOnCode(): void
@@ -32,6 +34,7 @@ class RFDeviceInformationTest extends TestCase
         $result = json_decode($response->getContent(), true);
 
         $this->assertEquals($result['code'], $this->onCode);
+        $this->assertEquals($result['pulse_length'], $this->pulseLength);
     }
 
     public function testInfo_GivenTurnOffAction_ReturnsJsonResponseWithCorrectOffCode(): void
@@ -43,6 +46,7 @@ class RFDeviceInformationTest extends TestCase
         $result = json_decode($response->getContent(), true);
 
         $this->assertEquals($result['code'], $this->offCode);
+        $this->assertEquals($result['pulse_length'], $this->pulseLength);
     }
 
     public function testInfo_GivenUnknownAction_Returns400(): void
@@ -59,7 +63,7 @@ class RFDeviceInformationTest extends TestCase
 
     private function callInfo(string $action): JsonResponse
     {
-        $rfDevice = $this->createRFDevice($this->onCode, $this->offCode);
+        $rfDevice = $this->createRFDevice($this->onCode, $this->offCode, $this->pulseLength);
 
         $mockRfDeviceRepository = Mockery::mock(RFDeviceRepository::class);
         $mockRfDeviceRepository->shouldReceive('get')->with($rfDevice->device_id)->once()->andReturn($rfDevice);
@@ -71,12 +75,13 @@ class RFDeviceInformationTest extends TestCase
         return $response;
     }
 
-    private function createRFDevice(int $onCode, int $offCode): RFDevice
+    private function createRFDevice(int $onCode, int $offCode, int $pulseLength): RFDevice
     {
         $rfDevice = factory(RFDevice::class)->make([
             'device_id' => self::$faker->randomNumber,
             'on_code' => $onCode,
-            'off_code' => $offCode
+            'off_code' => $offCode,
+            'pulse_length' => $pulseLength,
         ]);
 
         return $rfDevice;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->
<!--- Do not delete any section from here, if it doesn't apply, just leave it as is -->

## Description
When requesting information about an RF device, the pulse length was omitted.  This change will now publish an RF device's pulse length.  A corresponding change needs to be made to the RoboHome-ESP8266 repository to read the `pulse_length` value.  This addresses issue #126.

## Motivation and Context
If a user had a pulse length for an RF device other than the assumed value of 184 (found in the RoboHome-ESP8266 repository) then the device would not be able to be controlled.

## How Has This Been Tested?
Test cases were added to check that the pulse length was published.  I also ran Insomnia against the API endpoint `info` to verify that the pulse length now existed in the JSON response.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.