### PR TITLE
Use User's model "ownsDevice" function instead of reimplementation

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,52 +2,41 @@
 
 namespace App\Exceptions;
 
+use App\Traits\RestExceptionHandler;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class Handler extends ExceptionHandler
 {
-    /**
-     * A list of the exception types that are not reported.
-     *
-     * @var array
-     */
+    use RestExceptionHandler;
+
     protected $dontReport = [
         //
     ];
 
-    /**
-     * A list of the inputs that are never flashed for validation exceptions.
-     *
-     * @var array
-     */
     protected $dontFlash = [
         'password',
         'password_confirmation',
     ];
 
-    /**
-     * Report or log an exception.
-     *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @param  \Exception  $exception
-     * @return void
-     */
     public function report(Exception $exception): void
     {
         parent::report($exception);
     }
 
-    /**
-     * Render an exception into an HTTP response.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
-     */
-    public function render($request, Exception $exception)
+    public function render($request, Exception $exception): Response
     {
-        return parent::render($request, $exception);
+        if (!$this->isApiCall($request)) {
+            return parent::render($request, $exception);
+        }
+
+        return $this->jsonResponseForException($exception);
+    }
+
+    private function isApiCall(Request $request): bool
+    {
+        return strpos($request->getUri(), '/api/') !== false;
     }
 }

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -47,9 +47,9 @@ class DevicesController extends Controller
 
     public function delete(Request $request, int $id): RedirectResponse
     {
-        $doesUserOwnDevice = $request->user()->doesUserOwnDevice($id);
+        $userOwnsDevice = $request->user()->ownsDevice($id);
 
-        if (!$doesUserOwnDevice) {
+        if (!$userOwnsDevice) {
             $request->session()->flash(FlashMessageLevels::DANGER, 'Error deleting device!');
 
             return redirect()->route('devices');
@@ -69,9 +69,9 @@ class DevicesController extends Controller
 
     public function update(Request $request, int $id): RedirectResponse
     {
-        $doesUserOwnDevice = $request->user()->doesUserOwnDevice($id);
+        $userOwnsDevice = $request->user()->ownsDevice($id);
 
-        if (!$doesUserOwnDevice) {
+        if (!$userOwnsDevice) {
             $request->session()->flash(FlashMessageLevels::DANGER, 'Error updating device!');
 
             return redirect()->route('devices');
@@ -89,9 +89,9 @@ class DevicesController extends Controller
     public function handleControlRequest(Request $request, string $action, int $deviceId): RedirectResponse
     {
         $currentUser = $request->user();
-        $doesUserOwnDevice = $currentUser->doesUserOwnDevice($deviceId);
+        $userOwnsDevice = $currentUser->ownsDevice($deviceId);
 
-        if (!$doesUserOwnDevice) {
+        if (!$userOwnsDevice) {
             $request->session()->flash(FlashMessageLevels::DANGER, 'Error controlling device!');
 
             return redirect()->route('devices');

--- a/app/Traits/RestExceptionHandler.php
+++ b/app/Traits/RestExceptionHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Traits;
+
+use Exception;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+trait RestExceptionHandler
+{
+    protected function jsonResponseForException(Exception $exception): JsonResponse
+    {
+        switch (true) {
+            case $this->isAuthenticationException($exception):
+                return $this->notAuthenticated();
+            case $this->isModelNotFoundException($exception):
+                return $this->modelNotFound();
+            default:
+                return $this->badRequest();
+        }
+    }
+
+    private function notAuthenticated(): JsonResponse
+    {
+        return $this->jsonResponse(['error' => 'User not authenticated'], 401);
+    }
+
+    private function modelNotFound(): JsonResponse
+    {
+        return $this->jsonResponse(['error' => 'Record not found'], 404);
+    }
+
+    private function badRequest(): JsonResponse
+    {
+        return $this->jsonResponse(['error' => 'Bad request'], 400);
+    }
+
+    private function isAuthenticationException(Exception $exception): bool
+    {
+        return $exception instanceof AuthenticationException;
+    }
+
+    private function isModelNotFoundException(Exception $exception): bool
+    {
+        return $exception instanceof ModelNotFoundException;
+    }
+
+    private function jsonResponse(array $payload, int $statusCode): JsonResponse
+    {
+        return response()->json($payload, $statusCode);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -27,7 +27,7 @@ class User extends Authenticatable
         return $this->hasMany(Device::class);
     }
 
-    public function doesUserOwnDevice($deviceId): bool
+    public function ownsDevice($deviceId): bool
     {
         return $this->devices->contains($deviceId);
     }

--- a/tests/Browser/DevicesTest.php
+++ b/tests/Browser/DevicesTest.php
@@ -8,12 +8,20 @@ use Tests\DuskTestCase;
 
 class DevicesTest extends DuskTestCase
 {
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->createUser();
+    }
+
     public function testDevices_GivenUserLoggedIn_VerifyPath(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->assertPathIs('/devices');
         });
@@ -22,9 +30,8 @@ class DevicesTest extends DuskTestCase
     public function testDevices_GivenUserLoggedIn_SeesTitle(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->assertTitle('RoboHome | Devices');
         });
@@ -33,9 +40,8 @@ class DevicesTest extends DuskTestCase
     public function testDevices_GivenUserLoggedIn_SeesLogoutLink(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->assertSeeLink('Logout');
         });
@@ -44,10 +50,9 @@ class DevicesTest extends DuskTestCase
     public function testDevices_GivenUserLoggedIn_SeesHeaderWithUserName(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
-            $userName = $user->name;
+            $userName = $this->user->name;
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->assertSeeIn('@devices-table-header', "$userName's Controllable Devices");
         });
@@ -56,9 +61,8 @@ class DevicesTest extends DuskTestCase
     public function testDevices_GivenUserLoggedIn_ClicksLogout_RedirectToIndexPage(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->clickLink('Logout')
                 ->assertPathIs('/');
@@ -68,9 +72,8 @@ class DevicesTest extends DuskTestCase
     public function testDevices_GivenUserLoggedIn_ClicksAddDeviceButton_OpensAddDeviceModal(): void
     {
         $this->browse(function (Browser $browser) {
-            $user = $this->createUser();
             $browser
-                ->loginAs($user)
+                ->loginAs($this->user)
                 ->visit('/devices')
                 ->press('Add Device')
                 ->whenAvailable('#add-device-modal', function ($modal) {
@@ -203,10 +206,8 @@ class DevicesTest extends DuskTestCase
 
     private function loginAndAddDevice(Browser $browser, string $deviceName, string $deviceDescription, int $onCode, int $offCode, int $pulseLength) : Browser
     {
-        $user = $this->createUser();
-
         $browser
-            ->loginAs($user)
+            ->loginAs($this->user)
             ->visit('/devices')
             ->click('@open-add-device-button-modal')
             ->whenAvailable('#add-device-modal', function ($modal) use ($deviceName, $deviceDescription, $onCode, $offCode, $pulseLength) {

--- a/tests/unit/controller/web/DevicesControllerTest.php
+++ b/tests/unit/controller/web/DevicesControllerTest.php
@@ -341,10 +341,10 @@ class DevicesControllerTest extends DevicesControllerTestCase
         return $user;
     }
 
-    private function mockUserOwnsDevice(int $deviceId, bool $doesUserOwnDevice): User
+    private function mockUserOwnsDevice(int $deviceId, bool $userOwnsDevice): User
     {
         $mockUser = Mockery::mock(User::class);
-        $mockUser->shouldReceive('doesUserOwnDevice')->with($deviceId)->once()->andReturn($doesUserOwnDevice);
+        $mockUser->shouldReceive('ownsDevice')->with($deviceId)->once()->andReturn($userOwnsDevice);
 
         return $mockUser;
     }

--- a/tests/unit/controller/web/DevicesControllerTest.php
+++ b/tests/unit/controller/web/DevicesControllerTest.php
@@ -7,7 +7,6 @@ use App\Repositories\DeviceRepository;
 use App\User;
 use Illuminate\Foundation\Testing\TestResponse;
 use Mockery;
-use Mockery\MockInterface;
 use Tests\Unit\Controller\Common\DevicesControllerTestCase;
 
 class DevicesControllerTest extends DevicesControllerTestCase

--- a/tests/unit/model/UserTest.php
+++ b/tests/unit/model/UserTest.php
@@ -28,26 +28,26 @@ class UserTest extends TestCaseWithRealDatabase
         $this->assertEquals($numberOfDevices, $devices->count());
     }
 
-    public function testDoesUserOwnDevice_GivenFirstUserDoesNotOwnAnyDevices_ReturnsFalse(): void
+    public function testOwnsDevice_GivenFirstUserDoesNotOwnAnyDevices_ReturnsFalse(): void
     {
         $firstUser = $this->createUser();
         $secondUser = $this->createUser();
 
         $deviceIdForSecondUser = $this->createSingleDeviceForUser($secondUser)->id;
 
-        $doesUserOwnDevice = $firstUser->doesUserOwnDevice($deviceIdForSecondUser);
+        $userOwnsDevice = $firstUser->ownsDevice($deviceIdForSecondUser);
 
-        $this->assertFalse($doesUserOwnDevice);
+        $this->assertFalse($userOwnsDevice);
     }
 
-    public function testDoesUserOwnDevice_GivenUserOwnsDevice_ReturnsTrue(): void
+    public function testOwnsDevice_GivenUserOwnsDevice_ReturnsTrue(): void
     {
         $user = $this->createUser();
         $device = $this->createSingleDeviceForUser($user);
 
-        $doesUserOwnDevice = $user->doesUserOwnDevice($device->id);
+        $userOwnsDevice = $user->ownsDevice($device->id);
 
-        $this->assertTrue($doesUserOwnDevice);
+        $this->assertTrue($userOwnsDevice);
     }
 
     private function createUser(): User


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->
<!--- Do not delete any section from here, if it doesn't apply, just leave it as is -->

## Description
<!--- Describe your changes in detail -->
The `doesUserOwnDevice` function in the API's `DevicesController` is no longer needed and should have been removed a while ago in favor of the implementation of `ownsDevice` present in the `User` model.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clearer more concise use of existing methods.  Also makes testing a bit easier.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Added new unit tests and used Insomnia to hit the `info` endpoint with various different parameters to make sure 200, 401, and 404 errors are produced by the `info` endpoint as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.