### PR TITLE
Corrected method from POST to GET for MQTT settings

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -10,4 +10,4 @@ Route::resource('/devices', 'API\DevicesController');
 Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn')->middleware('scope:control');
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff')->middleware('scope:control');
 Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:info');
-Route::post('/settings/mqtt', 'API\SettingsController@mqtt')->name('mqttSettings')->middleware('scope:info');
+Route::get('/settings/mqtt', 'API\SettingsController@mqtt')->name('mqttSettings')->middleware('scope:info');

--- a/tests/Unit/Controller/API/SettingsControllerTest.php
+++ b/tests/Unit/Controller/API/SettingsControllerTest.php
@@ -10,7 +10,7 @@ class SettingsControllerTest extends ControllerTestCase
 {
     public function testMqtt_GivenUserNotLoggedIn_Returns401(): void
     {
-        $response = $this->postJson('/api/settings/mqtt');
+        $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(401);
     }
@@ -19,7 +19,7 @@ class SettingsControllerTest extends ControllerTestCase
     {
         Passport::actingAs(factory(User::class)->make(), [self::$faker->word()]);
 
-        $response = $this->postJson('/api/settings/mqtt');
+        $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(400);
     }
@@ -38,7 +38,7 @@ class SettingsControllerTest extends ControllerTestCase
 
         Passport::actingAs(factory(User::class)->make(), ['info']);
 
-        $response = $this->postJson('/api/settings/mqtt');
+        $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(200);
         $response->assertExactJson([


### PR DESCRIPTION
## Description
Noticed while developing the ESP-8266 that this should be a `GET` instead of a `POST` since there is no body of the request and we're only asking for information.

## Motivation and Context
Using the correct method is important for readability.  Also makes the ESP-8266 code a bit nicer.

## How Has This Been Tested?
All unit tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.
