### PR TITLE
Add public facing ID for users

### DIFF
--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -8,11 +8,12 @@ use App\Http\Globals\DeviceActions;
 use App\Http\MQTT\MessagePublisher;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Webpatser\Uuid\Uuid;
 
 class DevicesController extends Controller
 {
-    private $messagePublisher;
     private $deviceInformation;
+    private $messagePublisher;
 
     public function __construct(IDeviceInformation $deviceInformation, MessagePublisher $messagePublisher)
     {
@@ -70,7 +71,7 @@ class DevicesController extends Controller
     private function handleControlRequest(Request $request, string $action, string $responseName): JsonResponse
     {
         $user = $request->user();
-        $userId = $user->id;
+        $publicUserId = Uuid::import($user->public_id);
         $deviceId = $request->input('id');
 
         $userOwnsDevice = $user->ownsDevice($deviceId);
@@ -81,7 +82,7 @@ class DevicesController extends Controller
 
         $urlValidAction = strtolower($action);
 
-        $published = $this->messagePublisher->publish($userId, $urlValidAction, $deviceId);
+        $published = $this->messagePublisher->publish($publicUserId, $urlValidAction, $deviceId);
 
         if (!$published) {
             return response()->json(['error' => 'Message not published'], 500);

--- a/app/Http/Controllers/API/SettingsController.php
+++ b/app/Http/Controllers/API/SettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Common\Controller;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class SettingsController extends Controller
 {
@@ -12,14 +13,19 @@ class SettingsController extends Controller
         $this->middleware('auth:api');
     }
 
-    public function mqtt(): JsonResponse
+    public function mqtt(Request $request): JsonResponse
     {
+        $currentUser = $request->user();
+        $publicUserId = $currentUser->public_id;
+        $allDevicesForUserTopic = "RoboHome/$publicUserId/+";
+
         $response = [
             'mqtt' => [
                 'server' => getenv('MQTT_SERVER'),
                 'tlsPort' => getenv('MQTT_TLS_PORT'),
                 'user' => getenv('MQTT_USER'),
-                'password' => getenv('MQTT_PASSWORD')
+                'password' => getenv('MQTT_PASSWORD'),
+                'topic' => $allDevicesForUserTopic
             ]
         ];
 

--- a/app/Http/Controllers/API/UsersController.php
+++ b/app/Http/Controllers/API/UsersController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Common\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UsersController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:api');
+    }
+
+    public function publicId(Request $request): JsonResponse
+    {
+        $currentUser = $request->user();
+
+        return response()->json(['public_id' => $currentUser->public_id]);
+    }
+}

--- a/app/Http/Controllers/Web/DevicesController.php
+++ b/app/Http/Controllers/Web/DevicesController.php
@@ -9,6 +9,7 @@ use App\Repositories\IDeviceRepository;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
+use Webpatser\Uuid\Uuid;
 
 class DevicesController extends Controller
 {
@@ -85,7 +86,7 @@ class DevicesController extends Controller
             return $this->redirectToDevicesWithMessage($request, FlashMessageLevels::DANGER, 'Error controlling device!');
         }
 
-        $this->messagePublisher->publish($currentUser->id, $action, $deviceId);
+        $this->messagePublisher->publish(Uuid::import($currentUser->public_id), $action, $deviceId);
 
         return redirect()->route('devices');
     }

--- a/app/Http/MQTT/MessagePublisher.php
+++ b/app/Http/MQTT/MessagePublisher.php
@@ -3,6 +3,7 @@
 namespace App\Http\MQTT;
 
 use LibMQTT\Client;
+use Webpatser\Uuid\Uuid;
 
 class MessagePublisher
 {
@@ -13,13 +14,13 @@ class MessagePublisher
         $this->client = $client;
     }
 
-    public function publish(string $userId, string $action, int $deviceId): bool
+    public function publish(Uuid $publicUserId, string $action, int $deviceId): bool
     {
         if (!$this->client->connect()) {
             return false;
         }
 
-        $published = $this->client->publish("RoboHome/$userId/$deviceId", $action, 0);
+        $published = $this->client->publish("RoboHome/$publicUserId->string/$deviceId", $action, 0);
 
         $this->client->close();
 

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Passport\HasApiTokens;
+use Webpatser\Uuid\Uuid;
 
 class User extends Authenticatable
 {
@@ -21,6 +22,15 @@ class User extends Authenticatable
         'password',
         'remember_token'
     ];
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        self::creating(function (User $user) {
+            $user->public_id = Uuid::generate(4);
+        });
+    }
 
     public function devices(): HasMany
     {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "laravel/framework": "5.6.*",
         "laravel/passport": "~5.0",
         "laravel/tinker": "~1.0",
-        "mcfish/libmqtt": "^1.0.0"
+        "mcfish/libmqtt": "^1.0.0",
+        "webpatser/laravel-uuid": "^3.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e4cd8d2e7206f050cbd0e09e10976f4",
+    "content-hash": "c22cdf1dd4d5747215aad286463b3a72",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -2996,6 +2996,60 @@
                 "environment"
             ],
             "time": "2016-09-01T10:05:43+00:00"
+        },
+        {
+            "name": "webpatser/laravel-uuid",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webpatser/laravel-uuid.git",
+                "reference": "9c9bd4344f4aa78326b34a324d8a208e65c8221f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webpatser/laravel-uuid/zipball/9c9bd4344f4aa78326b34a324d8a208e65c8221f",
+                "reference": "9c9bd4344f4aa78326b34a324d8a208e65c8221f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "fzaninotto/faker": "~1.4",
+                "phpunit/phpunit": "~6.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Webpatser\\Uuid\\UuidServiceProvider"
+                    ],
+                    "aliases": {
+                        "Uuid": "Webpatser\\Uuid\\Uuid"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Webpatser\\Uuid": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Kempen",
+                    "email": "christoph@downsized.nl"
+                }
+            ],
+            "description": "Class to generate a UUID according to the RFC 4122 standard. Support for version 1, 3, 4 and 5 UUID are built-in.",
+            "homepage": "https://github.com/webpatser/uuid",
+            "keywords": [
+                "UUID RFC4122"
+            ],
+            "time": "2017-09-03T23:32:05+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -10,5 +10,6 @@ $factory->define(App\User::class, function (Faker $faker) {
         'email' => $faker->unique()->safeEmail(),
         'password' => $password ?: $password = bcrypt('secret'),
         'remember_token' => str_random(10),
+        'public_id' => $faker->uuid()
     ];
 });

--- a/database/migrations/2018_05_13_190907_add_public_id_to_users_table.php
+++ b/database/migrations/2018_05_13_190907_add_public_id_to_users_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\User;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Webpatser\Uuid\Uuid;
+
+class AddPublicIdToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('public_id')->after('remember_token')->default('');
+        });
+
+        foreach (User::all() as $user) {
+            $user->public_id = (string)Uuid::generate(4);
+            $user->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('public_id');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,3 +11,4 @@ Route::post('/devices/turnon', 'API\DevicesController@turnOn')->name('turnOn')->
 Route::post('/devices/turnoff', 'API\DevicesController@turnOff')->name('turnOff')->middleware('scope:control');
 Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:info');
 Route::get('/settings/mqtt', 'API\SettingsController@mqtt')->name('mqttSettings')->middleware('scope:info');
+Route::get('/users/publicId', 'API\UsersController@publicId')->name('publicId')->middleware('scope:info');

--- a/tests/Unit/Controller/API/DevicesControllerTest.php
+++ b/tests/Unit/Controller/API/DevicesControllerTest.php
@@ -291,10 +291,10 @@ class DevicesControllerTest extends DevicesControllerTestCase
 
     private function createMockUser(): User
     {
-        $userId = self::$faker->randomNumber();
+        $publicUserId = self::$faker->uuid();
 
         $mockUser = $mockUser = Mockery::mock(User::class)->makePartial();
-        $mockUser->shouldReceive('getAttribute')->with('id')->andReturn($userId);
+        $mockUser->shouldReceive('getAttribute')->with('public_id')->andReturn($publicUserId);
 
         return $mockUser;
     }

--- a/tests/Unit/Controller/API/SettingsControllerTest.php
+++ b/tests/Unit/Controller/API/SettingsControllerTest.php
@@ -26,27 +26,32 @@ class SettingsControllerTest extends ControllerTestCase
 
     public function testMqtt_GivenUserWithInfoScope_ReturnsMqttSettings(): void
     {
-        $server = self::$faker->domainName();
-        $tlsPort = self::$faker->randomNumber();
-        $user = self::$faker->email();
-        $password = self::$faker->password();
+        $user = factory(User::class)->make();
+        $publicUserId = $user->public_id;
 
-        putenv("MQTT_SERVER=$server");
-        putenv("MQTT_TLS_PORT=$tlsPort");
-        putenv("MQTT_USER=$user");
-        putenv("MQTT_PASSWORD=$password");
+        $mqttServer = self::$faker->domainName();
+        $mqttTlsPort = self::$faker->randomNumber();
+        $mqttUser = self::$faker->email();
+        $mqttPassword = self::$faker->password();
+        $mqttTopic = "RoboHome/$publicUserId/+";
 
-        Passport::actingAs(factory(User::class)->make(), ['info']);
+        putenv("MQTT_SERVER=$mqttServer");
+        putenv("MQTT_TLS_PORT=$mqttTlsPort");
+        putenv("MQTT_USER=$mqttUser");
+        putenv("MQTT_PASSWORD=$mqttPassword");
+
+        Passport::actingAs($user, ['info']);
 
         $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(200);
         $response->assertExactJson([
             'mqtt' => [
-                'server' => $server,
-                'tlsPort' => strval($tlsPort),
-                'user' => $user,
-                'password' => $password
+                'server' => $mqttServer,
+                'tlsPort' => strval($mqttTlsPort),
+                'user' => $mqttUser,
+                'password' => $mqttPassword,
+                'topic' => $mqttTopic
             ]
         ]);
     }

--- a/tests/Unit/Controller/API/UsersControllerTest.php
+++ b/tests/Unit/Controller/API/UsersControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Controller\API;
+
+use App\User;
+use Laravel\Passport\Passport;
+use Tests\Unit\Controller\Common\ControllerTestCase;
+
+class UsersControllerTest extends ControllerTestCase
+{
+    public function testPublicId_GivenUserWithRandomScope_Returns400(): void
+    {
+        Passport::actingAs(factory(User::class)->make(), [self::$faker->word()]);
+
+        $response = $this->getJson('/api/users/publicId');
+
+        $response->assertStatus(400);
+    }
+
+    public function testPublicId_GivenUserWithScope_Returns200(): void
+    {
+        $user = factory(User::class)->make();
+
+        Passport::actingAs($user, ['info']);
+
+        $response = $this->getJson('/api/users/publicId');
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['public_id' => $user->public_id]);
+    }
+}

--- a/tests/Unit/Controller/Web/DevicesControllerTest.php
+++ b/tests/Unit/Controller/Web/DevicesControllerTest.php
@@ -187,12 +187,12 @@ class DevicesControllerTest extends DevicesControllerTestCase
 
     public function testHandleControlRequest_GivenUserExistsWithDevice_CallsPublish(): void
     {
-        $userId = self::$faker->randomDigit();
+        $publicUserId = self::$faker->uuid();
         $deviceId = self::$faker->randomDigit();
         $action = self::$faker->word();
 
         $mockUser = $this->mockUserOwnsDevice($deviceId, true);
-        $mockUser->shouldReceive('getAttribute')->with('id')->once()->andReturn($userId);
+        $mockUser->shouldReceive('getAttribute')->with('public_id')->once()->andReturn($publicUserId);
 
         $this->mockMessagePublisher(1);
 

--- a/tests/Unit/MQTT/MessagePublisherTest.php
+++ b/tests/Unit/MQTT/MessagePublisherTest.php
@@ -6,10 +6,11 @@ use App\Http\MQTT\MessagePublisher;
 use LibMQTT\Client;
 use Mockery;
 use Tests\TestCase;
+use Webpatser\Uuid\Uuid;
 
 class MessagePublisherTest extends TestCase
 {
-    private $userId;
+    private $publicUserId;
     private $deviceId;
     private $action;
 
@@ -17,7 +18,7 @@ class MessagePublisherTest extends TestCase
     {
         parent::setUp();
 
-        $this->userId = self::$faker->uuid();
+        $this->publicUserId = Uuid::generate(4);
         $this->deviceId = self::$faker->randomDigit();
         $this->action = self::$faker->word();
     }
@@ -28,7 +29,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->userId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
 
         $this->assertTrue($result);
     }
@@ -39,7 +40,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->userId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
 
         $this->assertFalse($result);
     }
@@ -53,14 +54,14 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->userId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
 
         $this->assertFalse($result);
     }
 
     private function mockClient(bool $publishedSuccessfully)
     {
-        $topic = "RoboHome/$this->userId/$this->deviceId";
+        $topic = "RoboHome/$this->publicUserId/$this->deviceId";
 
         $mockClient = Mockery::mock(Client::class);
         $mockClient


### PR DESCRIPTION
## Description
It's never good practice to use your table's primary key as a public facing identifier.  Primary key's should only be used internally within the application itself.  Since this application has a public API, it is time to remove the usage of a `User` model's primary key as a public identifier.  This pull request introduces a database migration to add `public_id` to the `users` table and an API endpoint to access the currently authenticated user's `public_id`.  A corresponding change to the RoboHome-ESP8266 repository will be necessary to take advantage of this update.

## Motivation and Context
Security is the main reason for this change.  Using an autoincremented primary key to identify users leaves the API vulnerable to attack from bots that could easily guess a user's `id`.  With the addition of a `public_id` field which is a UUID v4 value, it's effectively impossible to iterate or guess users in the system.

## How Has This Been Tested?
Unit tests were added to cover this new API endpoint.  I also used Postman to manually hit the endpoint and make sure I get the expected `public_id`.  Lastly, I ran the migration locally to make sure both the `up()` and `down()` functions modified my database in an expected way.  Lastly, I used MQTT.fx to verify that the application was publishing messages with the new `public_id` in place of the old `id`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests passed.
