### PR TITLE
Add public facing ID for devices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Enhancement (non-breaking change which is not noticeable to end users)
+- [ ] Enhancement/Security (non-breaking change which is not noticeable to end users)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
 ## Checklist:
@@ -31,4 +31,4 @@
 - [ ] I have read the **CONTRIBUTING** document.
 - [ ] I have added tests to cover my changes.
 - [ ] This is a complete change and doesn't leave the project in a bad state.
-- [ ] All new and existing tests passed.
+- [ ] All new and existing tests pass.

--- a/app/Device.php
+++ b/app/Device.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Webpatser\Uuid\Uuid;
 
 class Device extends Model
 {
@@ -15,6 +16,10 @@ class Device extends Model
 
         static::deleting(function (Device $device) {
             $device->specificDevice()->delete();
+        });
+
+        self::creating(function (Device $device) {
+            $device->public_id = Uuid::generate(4);
         });
     }
 

--- a/app/Http/MQTT/MessagePublisher.php
+++ b/app/Http/MQTT/MessagePublisher.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\MQTT;
 
+use Illuminate\Support\Facades\Validator;
 use LibMQTT\Client;
 use Webpatser\Uuid\Uuid;
 
@@ -14,13 +15,13 @@ class MessagePublisher
         $this->client = $client;
     }
 
-    public function publish(Uuid $publicUserId, string $action, int $deviceId): bool
+    public function publish(string $action, Uuid $publicUserId, Uuid $publicDeviceId): bool
     {
         if (!$this->client->connect()) {
             return false;
         }
 
-        $published = $this->client->publish("RoboHome/$publicUserId->string/$deviceId", $action, 0);
+        $published = $this->client->publish("RoboHome/$publicUserId->string/$publicDeviceId->string", $action, 0);
 
         $this->client->close();
 

--- a/app/Providers/DeviceInformationServiceProvider.php
+++ b/app/Providers/DeviceInformationServiceProvider.php
@@ -20,12 +20,12 @@ class DeviceInformationServiceProvider extends ServiceProvider
 
     public function registerDeviceInformationTypes(Request $request): void
     {
-        if (!$request->has('deviceId')) {
+        if (!$request->has('publicDeviceId')) {
             $this->app->bind(IDeviceInformation::class, ErrantDeviceInformation::class);
             return;
         }
 
-        $deviceId = $request->get('deviceId');
+        $deviceId = $request->get('publicDeviceId');
 
         $deviceModel = app('App\Device');
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Webpatser\Uuid\Uuid;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -23,7 +24,15 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Route::pattern('id', '[0-9]+');
+        $lowercaseLettersOnly = '[a-z]+';
+        $uuidVersion4RegEx = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+        Route::pattern('action', $lowercaseLettersOnly);
+        Route::pattern('publicDeviceId', $uuidVersion4RegEx);
+
+        Route::bind('publicDeviceId', function (string $value) {
+            return Uuid::import($value);
+        });
 
         parent::boot();
     }

--- a/app/Repositories/DeviceRepository.php
+++ b/app/Repositories/DeviceRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Device;
 use App\Http\Globals\DeviceTypes;
+use Webpatser\Uuid\Uuid;
 
 class DeviceRepository implements IDeviceRepository
 {
@@ -33,6 +34,11 @@ class DeviceRepository implements IDeviceRepository
     public function get(int $id): Device
     {
         return Device::findOrFail($id);
+    }
+
+    public function getForPublicId(Uuid $publicId): Device
+    {
+        return Device::where('public_id', (string)$publicId)->firstOrFail();
     }
 
     public function update(int $id, array $deviceProperties): Device

--- a/app/Repositories/IDeviceRepository.php
+++ b/app/Repositories/IDeviceRepository.php
@@ -3,11 +3,13 @@
 namespace App\Repositories;
 
 use App\Device;
+use Webpatser\Uuid\Uuid;
 
 interface IDeviceRepository
 {
     public function create(array $deviceProperties, int $userId): Device;
     public function get(int $id): Device;
+    public function getForPublicId(Uuid $publicId): Device;
     public function update(int $id, array $deviceProperties): Device;
     public function delete(int $id): bool;
     public function name(int $id): string;

--- a/database/factories/DeviceFactory.php
+++ b/database/factories/DeviceFactory.php
@@ -10,6 +10,7 @@ $factory->define(App\Device::class, function (Faker $faker) {
         'user_id' => function () {
             return factory(App\User::class)->make()->id;
         },
-        'device_type_id' => DeviceTypes::RF_DEVICE
+        'device_type_id' => DeviceTypes::RF_DEVICE,
+        'public_id' => $faker->uuid()
     ];
 });

--- a/database/migrations/2018_05_16_014814_add_public_id_to_devices_table.php
+++ b/database/migrations/2018_05_16_014814_add_public_id_to_devices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Device;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Webpatser\Uuid\Uuid;
+
+class AddPublicIdToDevicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->uuid('public_id')->after('user_id')->default('');
+        });
+
+        foreach (Device::all() as $device) {
+            $device->public_id = (string)Uuid::generate(4);
+            $device->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('public_id');
+        });
+    }
+}

--- a/resources/views/devices.blade.php
+++ b/resources/views/devices.blade.php
@@ -7,7 +7,7 @@
                 $('#edit-device-modal').on('show.bs.modal', function (event) {
                     var button = $(event.relatedTarget);
 
-                    var deviceId = button.data('device-id');
+                    var devicePublicId = button.data('device-public-id');
                     var deviceName = button.data('device-name');
                     var deviceDescription = button.data('device-description');
                     var deviceOnCode = button.data('device-on-code');
@@ -16,7 +16,7 @@
 
                     var modal = $(this);
 
-                    modal.find('#device-update-form').attr('action', '/devices/update/' + deviceId)
+                    modal.find('#device-update-form').attr('action', '/devices/update/' + devicePublicId)
                     modal.find('#device-name-input').val(deviceName);
                     modal.find('#device-description-input').val(deviceDescription);
                     modal.find('#device-on-code-input').val(deviceOnCode);
@@ -25,13 +25,13 @@
                 })
             });
 
-            function controlDevice(action, id) {
+            function controlDevice(action, publicDeviceId) {
                 $.ajax({
                     headers: {
                         'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
                     },
                     type: "POST",
-                    url: "/devices/" + action + "/" + id
+                    url: "/devices/" + action + "/" + publicDeviceId
                 });
             }
         </script>
@@ -83,12 +83,12 @@
                                                 </button>
                                                 <ul class="dropdown-menu">
                                                     <li>
-                                                        <a href="#edit-device-modal" aria-label="Edit Device" data-toggle="modal" data-target="#edit-device-modal" data-device-id="{{ $device->id }}" data-device-name="{{ $device->name }}" data-device-description="{{ $device->description }}" @foreach($device->htmlDataAttributesForSpecificDevice() as $property) {{ $property }} @endforeach>
+                                                        <a href="#edit-device-modal" aria-label="Edit Device" data-toggle="modal" data-target="#edit-device-modal" data-device-public-id="{{ $device->public_id }}" data-device-name="{{ $device->name }}" data-device-description="{{ $device->description }}" @foreach($device->htmlDataAttributesForSpecificDevice() as $property) {{ $property }} @endforeach>
                                                             <span class="glyphicon glyphicon-pencil"></span> Edit
                                                         </a>
                                                     </li>
                                                     <li>
-                                                        <a href="/devices/delete/{{ $device->id }}">
+                                                        <a href="/devices/delete/{{ $device->public_id }}">
                                                             <span class="glyphicon glyphicon-remove"></span> Delete
                                                         </a>
                                                     </li>
@@ -105,8 +105,8 @@
                                         </td>
                                         <td class="col-xs-5">
                                             <div class="btn-group pull-right" role="group" aria-label="Device Controls">
-                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnon', '{{ $device->id }}');">On</button>
-                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnoff', '{{ $device->id }}');">Off</button>
+                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnon', '{{ $device->public_id }}');">On</button>
+                                                <button type="button" class="btn btn-primary" onclick="controlDevice('turnoff', '{{ $device->public_id }}');">Off</button>
                                             </div>
                                         </td>
                                     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,8 +8,6 @@ Auth::routes();
 
 Route::get('/devices', 'Web\DevicesController@devices')->name('devices');
 Route::post('/devices/add', 'Web\DevicesController@add')->name('addDevice');
-Route::get('/devices/delete/{id}', 'Web\DevicesController@delete')->name('deleteDevice');
-Route::put('/devices/update/{id}', 'Web\DevicesController@update')->name('updateDevice');
-Route::post('/devices/{action}/{id}', 'Web\DevicesController@handleControlRequest')
-    ->where(['action' => '[a-z]+'])
-    ->name('handleControlRequest');
+Route::get('/devices/delete/{publicDeviceId}', 'Web\DevicesController@delete')->name('deleteDevice');
+Route::put('/devices/update/{publicDeviceId}', 'Web\DevicesController@update')->name('updateDevice');
+Route::post('/devices/{action}/{publicDeviceId}', 'Web\DevicesController@handleControlRequest')->name('handleControlRequest');

--- a/tests/Unit/Controller/Web/DevicesControllerTest.php
+++ b/tests/Unit/Controller/Web/DevicesControllerTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Unit\Controller\Web;
 
 use App\Device;
-use App\Repositories\DeviceRepository;
+use App\Repositories\IDeviceRepository;
 use App\User;
 use Illuminate\Foundation\Testing\TestResponse;
 use Mockery;
 use Tests\Unit\Controller\Common\DevicesControllerTestCase;
+use Webpatser\Uuid\Uuid;
 
 class DevicesControllerTest extends DevicesControllerTestCase
 {
@@ -39,7 +40,7 @@ class DevicesControllerTest extends DevicesControllerTestCase
 
         $mockDevice = Mockery::mock(Device::class);
         $mockDevice
-            ->shouldReceive('getAttribute')->with('id')->atLeast()->once()->andReturn(self::$faker->randomDigit())
+            ->shouldReceive('getAttribute')->with('public_id')->atLeast()->once()->andReturn(self::$faker->randomDigit())
             ->shouldReceive('getAttribute')->with('name')->atLeast()->once()->andReturn($deviceName)
             ->shouldReceive('getAttribute')->with('description')->atLeast()->once()->andReturn($deviceDescription)
             ->shouldReceive('htmlDataAttributesForSpecificDevice')->once()->andReturn([ $htmlAttribute ]);
@@ -62,7 +63,7 @@ class DevicesControllerTest extends DevicesControllerTestCase
     public function testAdd_GivenPostedData_CallsAddOnModelsThenRedirectsToDevices(): void
     {
         $user = $this->makeUser();
-        $device = factory(Device::class)->make();
+        $device = $this->makeDevice();
 
         $response = $this->callAdd($device, $user);
 
@@ -72,7 +73,7 @@ class DevicesControllerTest extends DevicesControllerTestCase
     public function testAdd_GivenSingleUserExists_SessionContainsSuccessMessage(): void
     {
         $user = $this->makeUser();
-        $device = factory(Device::class)->make();
+        $device = $this->makeDevice();
 
         $response = $this->callAdd($device, $user);
 
@@ -112,6 +113,16 @@ class DevicesControllerTest extends DevicesControllerTestCase
         $response = $this->callDeleteOnDeviceUserOwns(false);
 
         $response->assertSessionHas('alert-danger');
+    }
+
+    public function testDelete_GivenInvalidUrlParameter_Returns404(): void
+    {
+        $user = $this->makeUser();
+        $invalidUrlParameter = (string)self::$faker->randomNumber();
+
+        $response = $this->actingAs($user)->get("/devices/delete/$invalidUrlParameter");
+
+        $response->assertNotFound();
     }
 
     public function testUpdate_GivenUserDoesNotOwnDevice_RedirectToDevices(): void
@@ -158,54 +169,80 @@ class DevicesControllerTest extends DevicesControllerTestCase
         $response->assertSessionHas('alert-success');
     }
 
+    public function testUpdate_GivenInvalidUrlParameter_Returns404(): void
+    {
+        $user = $this->makeUser();
+        $invalidUrlParameter = (string)self::$faker->randomNumber();
+
+        $response = $this->putToUpdateWithUserAndDeviceId($user, $invalidUrlParameter);
+
+        $response->assertNotFound();
+    }
+
     public function testHandleControlRequest_GivenUserExistsWithNoDevices_PublishIsNotCalled(): void
     {
-        $deviceId = self::$faker->randomDigit();
+        $device = $this->makeDevice();
+        $publicDeviceId = $device->public_id;
         $action = self::$faker->word();
 
-        $mockUser = $this->mockUserOwnsDevice($deviceId, false);
+        $mockUser = $this->mockUserOwnsDevice($device->id, false);
         $mockUser->shouldReceive('getAttribute')->with('id')->never();
 
         $this->mockMessagePublisher(0);
+        $this->givenGetForPublicIdCalledForDevice($device);
 
-        $response = $this->callControl($mockUser, $action, $deviceId);
+        $response = $this->callControl($mockUser, $action, $publicDeviceId);
 
         $this->assertRedirectedToRouteWith302($response, '/devices');
     }
 
     public function testHandleControlRequest_GivenUserExistsWithNoDevices_SessionContainsErrorMessage(): void
     {
-        $deviceId = self::$faker->randomDigit();
+        $device = $this->makeDevice();
+        $publicDeviceId = $device->public_id;
         $action = self::$faker->word();
 
-        $mockUser = $this->mockUserOwnsDevice($deviceId, false);
+        $mockUser = $this->mockUserOwnsDevice($device->id, false);
 
-        $response = $this->callControl($mockUser, $action, $deviceId);
+        $this->givenGetForPublicIdCalledForDevice($device);
+
+        $response = $this->callControl($mockUser, $action, $publicDeviceId);
 
         $response->assertSessionHas('alert-danger');
     }
 
     public function testHandleControlRequest_GivenUserExistsWithDevice_CallsPublish(): void
     {
-        $publicUserId = self::$faker->uuid();
-        $deviceId = self::$faker->randomDigit();
+        $device = $this->makeDevice();
+        $publicUserId = $device->public_id;
         $action = self::$faker->word();
 
-        $mockUser = $this->mockUserOwnsDevice($deviceId, true);
+        $mockUser = $this->mockUserOwnsDevice($device->id, true);
         $mockUser->shouldReceive('getAttribute')->with('public_id')->once()->andReturn($publicUserId);
+
+        $this->givenGetForPublicIdCalledForDevice($device);
 
         $this->mockMessagePublisher(1);
 
-        $response = $this->callControl($mockUser, $action, $deviceId);
+        $response = $this->callControl($mockUser, $action, $publicUserId);
 
         $this->assertRedirectedToRouteWith302($response, '/devices');
     }
 
+    public function testHandleControlRequest_GivenInvalidUrlParameter_Returns404(): void
+    {
+        $user = $this->makeUser();
+        $invalidUrlParameter = (string)self::$faker->randomNumber();
+        $action = self::$faker->word();
+
+        $response = $this->callControl($user, $action, $invalidUrlParameter);
+
+        $response->assertNotFound();
+    }
+
     private function callAdd(Device $device, User $user): TestResponse
     {
-        $mockDeviceRepository = $this->givenActionCalledOnDeviceRepository($device, 'create');
-
-        $this->app->instance(DeviceRepository::class, $mockDeviceRepository);
+        $this->givenActionCalledOnDeviceRepository($device, 'create');
 
         $csrfToken = self::$faker->uuid();
 
@@ -222,63 +259,78 @@ class DevicesControllerTest extends DevicesControllerTestCase
 
     private function callDeleteOnDeviceUserDoesNotOwn(): TestResponse
     {
-        $deviceId = self::$faker->randomDigit();
+        $device = $this->makeDevice();
+        $deviceId = $device->id;
+        $publicDeviceId = $device->public_id;
 
         $mockUser = $this->mockUserOwnsDevice($deviceId, false);
 
-        $mockDeviceRepository = Mockery::mock(DeviceRepository::class);
+        $mockDeviceRepository = Mockery::mock(IDeviceRepository::class);
         $mockDeviceRepository
             ->shouldReceive('name')->never()->with($deviceId)
+            ->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($publicDeviceId) {
+                return $argument instanceof Uuid && $argument == Uuid::import($publicDeviceId);
+            }))->once()->andReturn($device)
             ->shouldReceive('delete')->never()->with($deviceId);
 
-        $this->app->instance(DeviceRepository::class, $mockDeviceRepository);
+        $this->app->instance(IDeviceRepository::class, $mockDeviceRepository);
 
-        return $this->actingAs($mockUser)->get("/devices/delete/$deviceId");
+        return $this->actingAs($mockUser)->get("/devices/delete/$publicDeviceId");
     }
 
     private function callDeleteOnDeviceUserOwns(bool $wasDeleteSuccessful = true): TestResponse
     {
-        $deviceId = self::$faker->randomDigit();
+        $device = $this->makeDevice();
+        $deviceId = $device->id;
+        $publicDeviceId = $device->public_id;
 
         $mockUser = $this->mockUserOwnsDevice($deviceId, true);
 
-        $mockDeviceRepository = Mockery::mock(DeviceRepository::class);
+        $mockDeviceRepository = Mockery::mock(IDeviceRepository::class);
         $mockDeviceRepository
             ->shouldReceive('name')->once()->with($deviceId)
+            ->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($publicDeviceId) {
+                return $argument instanceof Uuid && $argument == Uuid::import($publicDeviceId);
+            }))->once()->andReturn($device)
             ->shouldReceive('delete')->once()->with($deviceId)->andReturn($wasDeleteSuccessful);
 
-        $this->app->instance(DeviceRepository::class, $mockDeviceRepository);
+        $this->app->instance(IDeviceRepository::class, $mockDeviceRepository);
 
-        $response = $this->actingAs($mockUser)->get("/devices/delete/$deviceId");
+        $response = $this->actingAs($mockUser)->get("/devices/delete/$publicDeviceId");
 
         return $response;
     }
 
     private function callUpdateOnDeviceUserDoesNotOwn(User $user, Device $device): TestResponse
     {
-        $mockDeviceRepository = Mockery::mock(DeviceRepository::class);
-        $mockDeviceRepository->shouldReceive('update')->never();
+        $mockDeviceRepository = Mockery::mock(IDeviceRepository::class);
+        $mockDeviceRepository
+            ->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($device) {
+                return $argument instanceof Uuid && $argument == Uuid::import($device->public_id);
+            }))->once()->andReturn($device)
+            ->shouldReceive('update')->never();
 
-        $this->app->instance(DeviceRepository::class, $mockDeviceRepository);
+        $this->app->instance(IDeviceRepository::class, $mockDeviceRepository);
 
-        return $this->putToUpdateWithUserAndDeviceId($user, $device->id);
+        return $this->putToUpdateWithUserAndDeviceId($user, $device->public_id);
     }
 
     private function callUpdateOnDeviceUserOwns(User $user, Device $device): TestResponse
     {
         $mockDeviceRepository = $this->givenActionCalledOnDeviceRepository($device, 'update');
+        $mockDeviceRepository->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($device) {
+            return $argument instanceof Uuid && $argument == Uuid::import($device->public_id);
+        }))->once()->andReturn($device);
 
-        $this->app->instance(DeviceRepository::class, $mockDeviceRepository);
-
-        return $this->putToUpdateWithUserAndDeviceId($user, $device->id);
+        return $this->putToUpdateWithUserAndDeviceId($user, $device->public_id);
     }
 
-    private function putToUpdateWithUserAndDeviceId(User $user, int $deviceId): TestResponse
+    private function putToUpdateWithUserAndDeviceId(User $user, string $publicDeviceId): TestResponse
     {
         $csrfToken = self::$faker->uuid();
 
         return $this->actingAs($user)->withSession(['_token' => $csrfToken])
-            ->put("/devices/update/$deviceId", [
+            ->put("/devices/update/$publicDeviceId", [
                 'name' => self::$faker->word(),
                 'description' => self::$faker->sentence(),
                 'on_code' => self::$faker->randomNumber(),
@@ -288,12 +340,12 @@ class DevicesControllerTest extends DevicesControllerTestCase
             ]);
     }
 
-    private function callControl(User $user, string $action, int $deviceId): TestResponse
+    private function callControl(User $user, string $action, string $publicDeviceId): TestResponse
     {
         $csrfToken = self::$faker->uuid();
 
         return $this->actingAs($user)->withSession(['_token' => $csrfToken])
-            ->post("/devices/$action/$deviceId", [
+            ->post("/devices/$action/$publicDeviceId", [
                 '_token' => $csrfToken
             ]);
     }
@@ -320,11 +372,21 @@ class DevicesControllerTest extends DevicesControllerTestCase
         return $mockUser;
     }
 
-    private function givenActionCalledOnDeviceRepository(Device $device, string $action): DeviceRepository
+    private function givenActionCalledOnDeviceRepository(Device $device, string $action): IDeviceRepository
     {
-        $mockDeviceRepository = Mockery::mock(DeviceRepository::class);
+        $mockDeviceRepository = Mockery::mock(IDeviceRepository::class);
         $mockDeviceRepository->shouldReceive($action)->once()->andReturn($device);
 
-        return $mockDeviceRepository;
+        return $this->app->instance(IDeviceRepository::class, $mockDeviceRepository);
+    }
+
+    private function givenGetForPublicIdCalledForDevice(Device $device): void
+    {
+        $mockDeviceRepository = Mockery::mock(IDeviceRepository::class);
+        $mockDeviceRepository->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($device) {
+            return $argument instanceof Uuid && $argument == Uuid::import($device->public_id);
+        }))->once()->andReturn($device);
+
+        $this->app->instance(IDeviceRepository::class, $mockDeviceRepository);
     }
 }

--- a/tests/Unit/MQTT/MessagePublisherTest.php
+++ b/tests/Unit/MQTT/MessagePublisherTest.php
@@ -11,7 +11,7 @@ use Webpatser\Uuid\Uuid;
 class MessagePublisherTest extends TestCase
 {
     private $publicUserId;
-    private $deviceId;
+    private $publicDeviceId;
     private $action;
 
     public function setUp(): void
@@ -19,7 +19,7 @@ class MessagePublisherTest extends TestCase
         parent::setUp();
 
         $this->publicUserId = Uuid::generate(4);
-        $this->deviceId = self::$faker->randomDigit();
+        $this->publicDeviceId = Uuid::generate(4);
         $this->action = self::$faker->word();
     }
 
@@ -29,7 +29,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->action, $this->publicUserId, $this->publicDeviceId);
 
         $this->assertTrue($result);
     }
@@ -40,7 +40,7 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->action, $this->publicUserId, $this->publicDeviceId);
 
         $this->assertFalse($result);
     }
@@ -54,14 +54,14 @@ class MessagePublisherTest extends TestCase
 
         $messagePublisher = new MessagePublisher($mockClient);
 
-        $result = $messagePublisher->publish($this->publicUserId, $this->action, $this->deviceId);
+        $result = $messagePublisher->publish($this->action, $this->publicUserId, $this->publicDeviceId);
 
         $this->assertFalse($result);
     }
 
     private function mockClient(bool $publishedSuccessfully)
     {
-        $topic = "RoboHome/$this->publicUserId/$this->deviceId";
+        $topic = "RoboHome/$this->publicUserId/$this->publicDeviceId";
 
         $mockClient = Mockery::mock(Client::class);
         $mockClient

--- a/tests/Unit/Repositories/DeviceRepositoryTest.php
+++ b/tests/Unit/Repositories/DeviceRepositoryTest.php
@@ -8,6 +8,7 @@ use App\Repositories\IRFDeviceRepository;
 use App\RFDevice;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Mockery;
+use Webpatser\Uuid\Uuid;
 
 class DeviceRepositoryTest extends RepositoryTestCaseWithRealDatabase
 {
@@ -43,11 +44,30 @@ class DeviceRepositoryTest extends RepositoryTestCaseWithRealDatabase
         $this->deviceRepository->get($nonexistentDeviceId);
     }
 
-    public function testGet_GivenDeviceExists_ReturnsRFDevice(): void
+    public function testGet_GivenDeviceExists_ReturnsDevice(): void
     {
         $device = $this->createDevice();
 
         $retrievedDevice = $this->deviceRepository->get($device->id);
+
+        $this->assertTrue($retrievedDevice->is($device));
+    }
+
+    public function testGetForPublicId_GivenDeviceDoesNotExist_ThrowsModelNotFoundException(): void
+    {
+        $nonexistentPublicDeviceId = Uuid::import(self::$faker->uuid());
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $this->deviceRepository->getForPublicId($nonexistentPublicDeviceId);
+    }
+
+    public function testGetForPublicId_GivenDeviceExists_ReturnsDevice(): void
+    {
+        $device = $this->createDevice();
+        $publicDeviceId = Uuid::import($device->public_id);
+
+        $retrievedDevice = $this->deviceRepository->getForPublicId($publicDeviceId);
 
         $this->assertTrue($retrievedDevice->is($device));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->
<!--- Do not delete any section from here, if it doesn't apply, just leave it as is -->

## Description
Similar to #144 

It's never good practice to use your table's primary key as a public facing identifier. Primary key's should only be used internally within the application itself. Since this application has a public API, it is time to remove the usage of a `Device` model's primary key as a public identifier. This pull request introduces a database migration to add `public_id` to the `devices` table. A corresponding change to the RoboHome-ESP8266 repository will be necessary to take advantage of this update.

## Motivation and Context
Security is the main reason for this change.  Using an autoincremented primary key to identify users leaves the API vulnerable to attack from bots that could easily guess a user's id. With the addition of a `public_id` field which is a UUID v4 value, it's effectively impossible to iterate or guess users in the system.

## How Has This Been Tested?
I used Postman to manually hit the endpoints and make sure I could send the expected `public_id` in requests. Lastly, I ran the migration locally to make sure both the `up()` and `down()` functions modified my database in an expected way. Lastly, I used MQTT.fx to verify that the application was publishing messages with the new `public_id` in place of the old `id`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests pass.