### PR TITLE
Simplify device ownership via new middleware

### DIFF
--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Device;
 use App\DeviceActionInfo\IDeviceActionInfoBroker;
 use App\Http\Controllers\Common\Controller;
 use App\Http\Globals\DeviceActions;
@@ -45,16 +44,9 @@ class DevicesController extends Controller
 
     public function info(Request $request): JsonResponse
     {
-        $user = $request->user();
         $publicDeviceId = $request->get('publicDeviceId');
         $action = $request->get('action');
         $device = $this->deviceRepository->getForPublicId(Uuid::import($publicDeviceId));
-
-        $userOwnsDevice = $user->ownsDevice($device->id);
-
-        if (!$userOwnsDevice) {
-            return response()->json(['error' => 'Unauthorized'], 401);
-        }
 
         return $this->deviceInformationBroker->infoNeededToPerformDeviceAction($device, $action);
     }
@@ -64,13 +56,6 @@ class DevicesController extends Controller
         $user = $request->user();
         $publicUserId = Uuid::import($user->public_id);
         $publicDeviceId = Uuid::import($request->input('publicDeviceId'));
-        $deviceId = $this->deviceRepository->getForPublicId($publicDeviceId)->id;
-
-        $userOwnsDevice = $user->ownsDevice($deviceId);
-
-        if (!$userOwnsDevice) {
-            return response()->json(['error' => 'Unauthorized'], 401);
-        }
 
         $urlValidAction = strtolower($action);
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,5 +60,6 @@ class Kernel extends HttpKernel
         'scope' => \Laravel\Passport\Http\Middleware\CheckForAnyScope::class,
         'scopes' => \Laravel\Passport\Http\Middleware\CheckScopes::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'apiVerifyUserOwnsDevice' =>  \App\Http\Middleware\ApiVerifyUserOwnsDevice::class,
     ];
 }

--- a/app/Http/Middleware/ApiVerifyUserOwnsDevice.php
+++ b/app/Http/Middleware/ApiVerifyUserOwnsDevice.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Repositories\IDeviceRepository;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Webpatser\Uuid\Uuid;
+
+class ApiVerifyUserOwnsDevice
+{
+    private $deviceRepository;
+
+    public function __construct(IDeviceRepository $deviceRepository)
+    {
+        $this->deviceRepository = $deviceRepository;
+    }
+
+    public function handle(Request $request, Closure $next): JsonResponse
+    {
+        $user = $request->user();
+        $publicDeviceId = $request->get('publicDeviceId');
+
+        $device = $this->deviceRepository->getForPublicId(Uuid::import($publicDeviceId));
+
+        $userOwnsDevice = $user->ownsDevice($device->id);
+
+        if (!$userOwnsDevice) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,7 +7,7 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:api', 'scope:control');
 
 Route::resource('/devices', 'API\DevicesController');
-Route::post('/devices/control/{action}', 'API\DevicesController@control')->name('control')->middleware('scope:control');
-Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:info');
+Route::post('/devices/control/{action}', 'API\DevicesController@control')->name('control')->middleware('scope:control', 'apiVerifyUserOwnsDevice');
+Route::post('/devices/info', 'API\DevicesController@info')->name('info')->middleware('scope:info', 'apiVerifyUserOwnsDevice');
 Route::get('/settings/mqtt', 'API\SettingsController@mqtt')->name('mqttSettings')->middleware('scope:info');
 Route::get('/users/publicId', 'API\UsersController@publicId')->name('publicId')->middleware('scope:info');

--- a/tests/Unit/Controller/API/DevicesControllerTest.php
+++ b/tests/Unit/Controller/API/DevicesControllerTest.php
@@ -146,12 +146,12 @@ class DevicesControllerTest extends DevicesControllerTestCase
             ->shouldReceive('infoNeededToPerformDeviceAction')
             ->once()
             ->withArgs([$device, $action])
-            ->andReturn(response()->json("test"));
+            ->andReturn(response()->json(self::$faker->word()));
         $this->app->instance(IDeviceActionInfoBroker::class, $mockDeviceActionInfoBroker);
 
         $this->mockDeviceRepository->shouldReceive('getForPublicId')->with(Mockery::on(function (Uuid $argument) use ($device) {
             return $argument instanceof Uuid && $argument == Uuid::import($device->public_id);
-        }))->once()->andReturn($device);
+        }))->times(2)->andReturn($device);
 
         $response = $this->callInfo($device->public_id, $action);
 


### PR DESCRIPTION
## Description
Instead of repeating code to check if a user owns a device, it is now implemented as middleware applied to certain API routes.  This also helps to address issue #95.

## Motivation and Context
DRY the API code and make it easier to maintain checking who owns a device.

## How Has This Been Tested?
All existing unit tests pass.  Using Postman, I was able to get the expected JSON response from the affected endpoints.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement/Security (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests pass.