### PR TITLE
Cleanup and make the tests more flexible

### DIFF
--- a/app/Http/Controllers/API/DevicesController.php
+++ b/app/Http/Controllers/API/DevicesController.php
@@ -44,9 +44,9 @@ class DevicesController extends Controller
 
     public function info(Request $request): JsonResponse
     {
-        $publicDeviceId = $request->get('publicDeviceId');
+        $publicDeviceId = Uuid::import($request->input('publicDeviceId'));
         $action = $request->get('action');
-        $device = $this->deviceRepository->getForPublicId(Uuid::import($publicDeviceId));
+        $device = $this->deviceRepository->getForPublicId($publicDeviceId);
 
         return $this->deviceInformationBroker->infoNeededToPerformDeviceAction($device, $action);
     }

--- a/tests/Unit/Controller/API/SettingsControllerTest.php
+++ b/tests/Unit/Controller/API/SettingsControllerTest.php
@@ -13,6 +13,7 @@ class SettingsControllerTest extends ControllerTestCase
         $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(401);
+        $response->assertExactJson(['error' => 'User not authenticated']);
     }
 
     public function testMqtt_GivenUserWithRandomScope_Returns400(): void
@@ -22,6 +23,7 @@ class SettingsControllerTest extends ControllerTestCase
         $response = $this->getJson('/api/settings/mqtt');
 
         $response->assertStatus(400);
+        $response->assertExactJson(['error' => 'Missing scope']);
     }
 
     public function testMqtt_GivenUserWithInfoScope_ReturnsMqttSettings(): void

--- a/tests/Unit/Controller/API/UsersControllerTest.php
+++ b/tests/Unit/Controller/API/UsersControllerTest.php
@@ -15,6 +15,7 @@ class UsersControllerTest extends ControllerTestCase
         $response = $this->getJson('/api/users/publicId');
 
         $response->assertStatus(400);
+        $response->assertExactJson(['error' => 'Missing scope']);
     }
 
     public function testPublicId_GivenUserWithScope_Returns200(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above using the present tense -->
<!--- Do not include the issue number or other pull request numbers in the title, but below in the description -->
<!--- Do not delete any section from here, if it doesn't apply, just leave it as is -->

## Description
After pull request #146 I noticed that the tests around the API's `DevicesController` could use some cleaning up.  Those tests were the main focus of this pull request.  I simplified it by picking a random device action using reflection to test the `control` function with instead of duplicating tests to test against each device action.  The reasoning here being which device action selected shouldn't affect the outcome of the test.  I also verified the JSON response on non-200 responses from multiple API classes to verify useful error messages were being sent back to the consumer.

## Motivation and Context
Easier to maintain tests and assurances for meaningful error messages in the API.

## How Has This Been Tested?
All new and existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement/Security (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I created a feature branch and did not open a pull request from my `master` branch.
- [X] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] This is a complete change and doesn't leave the project in a bad state.
- [X] All new and existing tests pass.
