### PR TITLE
Use SweetAlert to add confirmation after clicking delete

### DIFF
--- a/resources/views/devices.blade.php
+++ b/resources/views/devices.blade.php
@@ -2,6 +2,7 @@
     <head>
         <title>RoboHome | Devices</title>
         <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
         <script>
             $(document).ready(function() {
                 $('#edit-device-modal').on('show.bs.modal', function (event) {
@@ -32,6 +33,24 @@
                     },
                     type: "POST",
                     url: "/devices/" + action + "/" + publicDeviceId
+                });
+            }
+
+            function confirmBeforeDelete(that) {
+                let deviceName = $(that).data("device-name");
+                let deleteLink = $(that).data("delete-link");
+
+                swal({
+                    title: deviceName,
+                    text: "Are you sure you want to delete this device?",
+                    icon: "warning",
+                    buttons: true,
+                    dangerMode: true,
+                })
+                .then((willDelete) => {
+                    if (willDelete) {
+                        window.location.href = deleteLink;
+                    }
                 });
             }
         </script>
@@ -88,7 +107,7 @@
                                                         </a>
                                                     </li>
                                                     <li>
-                                                        <a href="/devices/delete/{{ $device->public_id }}">
+                                                    <a href="#" data-device-name="{{ $device->name }}" data-delete-link="/devices/delete/{{ $device->public_id }}" onclick="confirmBeforeDelete(this)">
                                                             <span class="glyphicon glyphicon-remove"></span> Delete
                                                         </a>
                                                     </li>

--- a/tests/Browser/DevicesTest.php
+++ b/tests/Browser/DevicesTest.php
@@ -123,11 +123,31 @@ class DevicesTest extends DuskTestCase
             $this->loginAndAddDevice($browser, $deviceName, $deviceDescription, $onCode, $offCode, $pulseLength)
                 ->press('@modify-device-button')
                 ->clickLink('Delete')
+                ->press('OK')
                 ->assertSeeIn('@success-flash-message', "Device '$deviceName' was successfully deleted!")
                 ->assertDontSeeIn('@devices-table', $deviceName)
                 ->assertDontSeeIn('@devices-table', $deviceDescription)
                 ->assertDontSee('@devices-table', 'On')
                 ->assertDontSee('@devices-table', 'Off');
+        });
+    }
+
+    public function testDevices_GivenUserLoggedIn_DeletesExistingDevice_UserCancelsDeleteOperation(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $deviceName = self::$faker->word();
+            $deviceDescription = self::$faker->sentence();
+            $onCode = self::$faker->randomNumber();
+            $offCode = self::$faker->randomNumber();
+            $pulseLength = self::$faker->randomNumber();
+
+            $this->loginAndAddDevice($browser, $deviceName, $deviceDescription, $onCode, $offCode, $pulseLength)
+                ->press('@modify-device-button')
+                ->clickLink('Delete')
+                ->press('Cancel')
+                ->assertDontSeeIn('@success-flash-message', "Device '$deviceName' was successfully deleted!")
+                ->assertSeeIn('@devices-table', $deviceName)
+                ->assertSeeIn('@devices-table', $deviceDescription);
         });
     }
 


### PR DESCRIPTION
Resolve #152

- Add confirmation javascript code
- Modify the test case for deletion
- Add a test case for canceling deletion

## Description
Add confirmation javascript code. This can be ubiquitous for any confirmation needs by adding class="confirmation".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Confirmation before any un-redoable action is great.
<!--- If it fixes an open issue, please link to the issue here. -->
[Add confirmation after clicking "Delete" button](https://github.com/dbudwin/RoboHome-Web/issues/152)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The change causes a js confirmation dialog before actual action. Add dialog check in test cases.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
test by laravel dusk `php artisan dusk`

## Screenshots (if appropriate):
<img width="664" alt="screen shot 2018-10-15 at 21 09 53" src="https://user-images.githubusercontent.com/15161181/46986678-b3943b80-d0be-11e8-8a03-712f8b39ac3e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement/Security (non-breaking change which is not noticeable to end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I created a feature branch and did not open a pull request from my `master` branch.
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the README and I have updated it accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] This is a complete change and doesn't leave the project in a bad state.
- [x] All new and existing tests pass.
